### PR TITLE
fixing #41 issue in exception handling and returning error string on Windows errors

### DIFF
--- a/pkcs11/_mswin.pxd
+++ b/pkcs11/_mswin.pxd
@@ -75,16 +75,16 @@ cdef extern from "Windows.h":
 cdef inline winerror(so) with gil:
     """
     returns the last error message, as a string.
-    If the string has '%1', it is substituted with the content of so arg.
+    If the string has '%1', it is substituted with the content of 'so' arg.
     """
     #
     # inspired from https://docs.microsoft.com/en-us/windows/desktop/debug/retrieving-the-last-error-code
     #
-    cdef LPWSTR messageBuffer = NULL
+    cdef LPWSTR msgbuffer = NULL
     dw = GetLastError()
-    errmsg=""
+    errmsg = ""
 
-    if dw!=0:
+    if dw != 0:
         # from https://docs.microsoft.com/en-us/windows/desktop/api/WinBase/nf-winbase-formatmessage
         # at 'Security Remarks':
         # In particular, it is unsafe to take an arbitrary system error code returned from an API
@@ -93,18 +93,17 @@ cdef inline winerror(so) with gil:
         # Given that remark, we are not attempting to parse inserts with a va_list.
         # Instead, we only substitute '%1' with the value of so argument, on the returned string.
         
-        FormatMessageW( FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                        NULL,
-                        dw,
-                        MAKELANGID(LANG_USER_DEFAULT, SUBLANG_DEFAULT),
-                        <LPWSTR>&messageBuffer,
-                        0,
-                        NULL )
+        FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER|FORMAT_MESSAGE_FROM_SYSTEM|FORMAT_MESSAGE_IGNORE_INSERTS,
+                       NULL,
+                       dw,
+                       MAKELANGID(LANG_USER_DEFAULT, SUBLANG_DEFAULT),
+                       <LPWSTR>&msgbuffer,
+                       0,
+                       NULL)
 
-        errmsg = <str>messageBuffer
-        LocalFree(messageBuffer)
+        errmsg = <str>msgbuffer # C to python string copy
+        LocalFree(msgbuffer)
         
     return errmsg.replace('%1', so)
 
-
-
+#EOF

--- a/pkcs11/_mswin.pxd
+++ b/pkcs11/_mswin.pxd
@@ -31,20 +31,80 @@ Definitions to support compilation on Windows platform
 cdef extern from "Windows.h":
     ctypedef unsigned long DWORD
     ctypedef Py_UNICODE wchar_t
+    ctypedef wchar_t *LPWSTR
     ctypedef const wchar_t *LPCWSTR
+    ctypedef char *LPSTR
     ctypedef const char *LPCSTR
     ctypedef void *PVOID
+    ctypedef const void *LPCVOID
     ctypedef PVOID HANDLE
+    ctypedef HANDLE HLOCAL
     ctypedef HANDLE HINSTANCE
     ctypedef HINSTANCE HMODULE
     ctypedef bint BOOL
+    ctypedef short INT16
+
+    ctypedef enum LANG_ID:
+        LANG_NEUTRAL
+        LANG_USER_DEFAULT
+        SUBLANG_DEFAULT
+
+    ctypedef enum FORMAT_FLAGS:
+        FORMAT_MESSAGE_ALLOCATE_BUFFER
+        FORMAT_MESSAGE_FROM_SYSTEM
+        FORMAT_MESSAGE_IGNORE_INSERTS
 
     HMODULE LoadLibraryW(LPCWSTR lpLibFileName)
     BOOL FreeLibrary(HMODULE hLinModule)
     PVOID GetProcAddress(HMODULE hModule, LPCSTR lpProcName)
     DWORD GetLastError()
 
-cdef inline _winerrormsg(self):
+    DWORD MAKELANGID(INT16 p, INT16 s)
+    DWORD FormatMessageW(
+        DWORD   dwFlags,
+        LPCVOID lpSource,
+        DWORD   dwMessageId,
+        DWORD   dwLanguageId,
+        LPWSTR  lpBuffer,
+        DWORD   nSize,
+        ...
+    )
+
+    HLOCAL LocalFree(HLOCAL handle)
+
+cdef inline winerror(so) with gil:
+    """
+    returns the last error message, as a string.
+    If the string has '%1', it is substituted with the content of so arg.
+    """
+    #
+    # inspired from https://docs.microsoft.com/en-us/windows/desktop/debug/retrieving-the-last-error-code
+    #
+    cdef LPWSTR messageBuffer = NULL
     dw = GetLastError()
-    # TODO: return error message from Windows, using FormatError()
-    return dw
+    errmsg=""
+
+    if dw!=0:
+        # from https://docs.microsoft.com/en-us/windows/desktop/api/WinBase/nf-winbase-formatmessage
+        # at 'Security Remarks':
+        # In particular, it is unsafe to take an arbitrary system error code returned from an API
+        # and use FORMAT_MESSAGE_FROM_SYSTEM without FORMAT_MESSAGE_IGNORE_INSERTS.
+        #
+        # Given that remark, we are not attempting to parse inserts with a va_list.
+        # Instead, we only substitute '%1' with the value of so argument, on the returned string.
+        
+        FormatMessageW( FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                        NULL,
+                        dw,
+                        MAKELANGID(LANG_USER_DEFAULT, SUBLANG_DEFAULT),
+                        <LPWSTR>&messageBuffer,
+                        0,
+                        NULL )
+
+        errmsg = <str>messageBuffer
+        LocalFree(messageBuffer)
+        
+    return errmsg.replace('%1', so)
+
+
+


### PR DESCRIPTION
Hi @danni,

Please find hereby a PR to fix issue #41. In addition, `winerror()` returns now a string now, which should ease troubleshooting. 

This PR passes local testing as well as travis build. (but admittedly, there is room for adding unit testing & matrix build for Windows).

For your review.

Eric