### PR TITLE
RFC 8410 (Ed25519 and friends)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ before_install:
     - pip install -U pip setuptools
     - pip install -r dev-requirements.txt
     # Install SoftHSMv2
-    - curl https://dist.opendnssec.org/source/softhsm-2.3.0.tar.gz | tar -zxv
-    - (cd softhsm-2.3.0 && ./configure --prefix=$HOME --disable-p11-kit && make all install CC="ccache gcc" CXX="ccache g++")
+    - curl https://dist.opendnssec.org/source/softhsm-2.5.0.tar.gz | tar -zxv
+    - (cd softhsm-2.5.0 && ./configure --prefix=$HOME --disable-p11-kit --disable-gost && make all install CC="ccache gcc" CXX="ccache g++")
 
 before_script:
     # Initialise a token on the SoftHSM

--- a/extern/pkcs11t.h
+++ b/extern/pkcs11t.h
@@ -4,7 +4,7 @@
  * IMPLIED OR EXPRESS WARRANTY; there is no warranty of MERCHANTABILITY, FITNESS FOR A
  * PARTICULAR PURPOSE or NONINFRINGEMENT of the rights of others.
  */
-        
+
 /* Latest version of the specification:
  * http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.html
  */
@@ -382,6 +382,9 @@ typedef CK_ULONG          CK_KEY_TYPE;
 #define CKK_GOSTR3410           0x00000030UL
 #define CKK_GOSTR3411           0x00000031UL
 #define CKK_GOST28147           0x00000032UL
+
+/* from version 3.0 */
+#define CKK_EC_EDWARDS          0x00000040UL
 
 
 
@@ -972,6 +975,10 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 
 #define CKM_RSA_PKCS_TPM_1_1           0x00004001UL
 #define CKM_RSA_PKCS_OAEP_TPM_1_1      0x00004002UL
+
+/* from version 3.0 */
+#define CKM_EC_EDWARDS_KEY_PAIR_GEN	   0x00001055UL
+#define CKM_EDDSA                      0x00001057UL
 
 #define CKM_VENDOR_DEFINED             0x80000000UL
 

--- a/pkcs11/defaults.py
+++ b/pkcs11/defaults.py
@@ -26,6 +26,7 @@ DEFAULT_GENERATE_MECHANISMS = {
     KeyType.EC: Mechanism.EC_KEY_PAIR_GEN,
     KeyType.RSA: Mechanism.RSA_PKCS_KEY_PAIR_GEN,
     KeyType.X9_42_DH: Mechanism.X9_42_DH_KEY_PAIR_GEN,
+    KeyType.EC_EDWARDS: Mechanism.EC_EDWARDS_KEY_PAIR_GEN,
 }
 """
 Default mechanisms for generating keys.
@@ -44,6 +45,7 @@ DEFAULT_KEY_CAPABILITIES = {
     KeyType.EC: _SIGNING | MechanismFlag.DERIVE,
     KeyType.RSA: _ENCRYPTION | _SIGNING | _WRAPPING,
     KeyType.GENERIC_SECRET: 0,
+    KeyType.EC_EDWARDS: _SIGNING,
 }
 """
 Default capabilities for generating keys.
@@ -66,6 +68,7 @@ DEFAULT_SIGN_MECHANISMS = {
     KeyType.DSA: Mechanism.DSA_SHA512,
     KeyType.EC: Mechanism.ECDSA_SHA512,
     KeyType.RSA: Mechanism.SHA512_RSA_PKCS,
+    KeyType.EC_EDWARDS: Mechanism.EDDSA,
 }
 """
 Default mechanisms for sign/verify.

--- a/pkcs11/mechanisms.py
+++ b/pkcs11/mechanisms.py
@@ -95,6 +95,9 @@ class KeyType(IntEnum):
     GOSTR3411 = 0x00000031
     GOST28147 = 0x00000032
 
+    # from version 3.0
+    EC_EDWARDS = 0x00000040
+
     _VENDOR_DEFINED = 0x80000000
 
     def __repr__(self):
@@ -698,6 +701,10 @@ class Mechanism(IntEnum):
     .. note:: Default mechanism for generating :attr:`KeyType.X9_42_DH` domain
         parameters (X9.42 DH).
     """
+
+    # from version 3.0
+    EDDSA = 0x00001057
+    EC_EDWARDS_KEY_PAIR_GEN = 0x00001055
 
     _VENDOR_DEFINED = 0x80000000
 

--- a/pkcs11/util/ec.py
+++ b/pkcs11/util/ec.py
@@ -14,15 +14,6 @@ from asn1crypto.core import OctetString
 from ..constants import Attribute, ObjectClass
 from ..mechanisms import KeyType
 
-# patch in RFC 8410 (https://tools.ietf.org/html/rfc8410)
-rfc_8410_oids = {
-    "X25519": "1.3.101.110",
-    "X448": "1.3.101.111",
-    "Ed25519": "1.3.101.112",
-    "Ed448": "1.3.101.113",
-}
-NamedCurve._map.update({v: k for k, v in rfc_8410_oids.items()})
-
 
 def encode_named_curve_parameters(oid):
     """

--- a/pkcs11/util/ec.py
+++ b/pkcs11/util/ec.py
@@ -11,9 +11,20 @@ from asn1crypto.keys import (
 )
 from asn1crypto.algos import DSASignature
 from asn1crypto.core import OctetString
-
 from ..constants import Attribute, ObjectClass
 from ..mechanisms import KeyType
+
+# patch in RFC 8410 (https://tools.ietf.org/html/rfc8410)
+rfc_8410_oids = {
+    "X25519": "1.3.101.110",
+    "X448": "1.3.101.111",
+    "Ed25519": "1.3.101.112",
+    "Ed448": "1.3.101.113",
+}
+NamedCurve._map = {
+    **NamedCurve._map,
+    **{v: k for k, v in rfc_8410_oids.items()},
+}
 
 
 def encode_named_curve_parameters(oid):

--- a/pkcs11/util/ec.py
+++ b/pkcs11/util/ec.py
@@ -21,10 +21,7 @@ rfc_8410_oids = {
     "Ed25519": "1.3.101.112",
     "Ed448": "1.3.101.113",
 }
-NamedCurve._map = {
-    **NamedCurve._map,
-    **{v: k for k, v in rfc_8410_oids.items()},
-}
+NamedCurve._map.update({v: k for k, v in rfc_8410_oids.items()})
 
 
 def encode_named_curve_parameters(oid):

--- a/tests/test_ecc.py
+++ b/tests/test_ecc.py
@@ -147,3 +147,19 @@ class ECCTests(TestCase):
         # signature = priv.sign(b'Example', mechanism=Mechanism.ECDSA)
         # self.assertTrue(pub.verify(b'Example', signature,
         #                            mechanism=Mechanism.ECDSA))
+
+    @requires(Mechanism.EC_EDWARDS_KEY_PAIR_GEN, Mechanism.EDDSA)
+    def test_sign_eddsa(self):
+        parameters = self.session.create_domain_parameters(KeyType.EC, {
+            # use "Ed25519" once https://github.com/wbond/asn1crypto/pull/134
+            # is merged
+            Attribute.EC_PARAMS: encode_named_curve_parameters('1.3.101.112')
+        }, local=True)
+
+        pub, priv = parameters.generate_keypair()
+
+        mechanism = Mechanism.EDDSA
+        data = b'HI BOB!'
+        eddsa = priv.sign(data, mechanism=mechanism)
+        self.assertTrue(pub.verify(data, eddsa, mechanism=mechanism))
+


### PR DESCRIPTION
I am interested in Ed25519 for inclusion in a Cryptoki interface to [our FIDO2 dongle](https://github.com/solokeys/solo). This curve is included in the [draft for Cryptoki v3.0](https://www.oasis-open.org/committees/document.php?document_id=62198&wg_abbrev=pkcs11), and implemented in [SoftHSMv2 version 2.5](https://github.com/opendnssec/SoftHSMv2/pull/362).

The OID patch would be removed if https://github.com/wbond/asn1crypto/pull/134 gets merged.

Submitting now for feedback. An automated test against SoftHSMv2 would be nice I guess :)
I ran the following against SoftHSM 2.5 successfully:
```
ed_params = session.create_domain_parameters(
    p11.KeyType.EC_EDWARDS,
    {
        p11.Attribute.EC_PARAMS: encode_named_curve_parameters("Ed25519")
    },
    local=True,
)
ed_pub, ed_priv = ed_params.generate_keypair()
data = b"python-pkcs11"
ed_priv.sign(data)
ed_pub.verify(data, ed_priv.sign(data))
```
