### PR TITLE
Attribute.COPYABLE

### DIFF
--- a/pkcs11/constants.py
+++ b/pkcs11/constants.py
@@ -260,6 +260,8 @@ class Attribute(IntEnum):
 
     MODIFIABLE = 0x00000170
     """Object can be modified (:class:`bool`)."""
+    COPYABLE = 0x00000171
+    """Object can be copied (:class:`bool`)."""
 
     EC_PARAMS = 0x00000180
     """

--- a/pkcs11/defaults.py
+++ b/pkcs11/defaults.py
@@ -158,6 +158,7 @@ ATTRIBUTE_TYPES = {
     Attribute.LABEL: _str,
     Attribute.LOCAL: _bool,
     Attribute.MODIFIABLE: _bool,
+    Attribute.COPYABLE: _bool,
     Attribute.MODULUS: _biginteger,
     Attribute.MODULUS_BITS: _ulong,
     Attribute.NEVER_EXTRACTABLE: _bool,


### PR DESCRIPTION

#### Changes
This defines the COPYABLE attribute in the int enum.
CKA_COPYABLE is 0x171
Source: http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html
Reviewers @danni