### PR TITLE
Fix empty slot error handling in _pkcs11.lib.get_tokens

### DIFF
--- a/pkcs11/_pkcs11.pyx
+++ b/pkcs11/_pkcs11.pyx
@@ -1310,10 +1310,10 @@ cdef class lib:
         """Search for a token matching the parameters."""
 
         for slot in self.get_slots():
-            token = slot.get_token()
-            token_mechanisms = slot.get_mechanisms()
-
             try:
+                token = slot.get_token()
+                token_mechanisms = slot.get_mechanisms()
+            
                 if token_label is not None and \
                         token.label != token_label:
                     continue


### PR DESCRIPTION
I was getting TokenNotPresent Exceptions when using lib.get_tokens(token_label="...") with multiple card readers, where the first slot didn't have a card in it. I think this try block was meant to be around the slot.get_token call all along.