### PR TITLE
Allow unpacking Attribute.APPLICATION for data objects

### DIFF
--- a/pkcs11/defaults.py
+++ b/pkcs11/defaults.py
@@ -135,6 +135,7 @@ def _enum(type_):
 ATTRIBUTE_TYPES = {
     Attribute.ALWAYS_AUTHENTICATE: _bool,
     Attribute.ALWAYS_SENSITIVE: _bool,
+    Attribute.APPLICATION: _str,
     Attribute.BASE: _biginteger,
     Attribute.CERTIFICATE_TYPE: _enum(CertificateType),
     Attribute.CHECK_VALUE: _bytes,


### PR DESCRIPTION
Data objects may have this additional RFC2279 string to identify the application an object belongs to.
See http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html#_Toc416959708 for the spec

I tested this change using a token that I created an object on using pkcs11-tool like this:
`pkcs11-tool --slot 0x2 --login --pin x --write-object ./testdata --type data --application-label app1 --label data1`