### PR TITLE
Add an example for dealing with DATA objects to the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -213,6 +213,51 @@ Elliptic-Curve Diffie-Hellman
             KeyType.AES, 128,
             mechanism_param=(KDF.NULL, None, other_value))
 
+Raw Data Objects
+~~~~~~~~~~~~~~~~~~
+
+This can be useful for storing symmetric encryption keys and the like. Be sure to set the Attribute PRIVATE to True, otherwise the Objects will be readable even without Pin login.
+
+import os, pkcs11
+
+    lib = pkcs11.lib(os.environ["PKCS11_MODULE"])
+    token = lib.get_token(token_label="DEMO")
+
+    demoapp = "python-pkcs11 demo"
+    demolabel = "testobject"
+    demodata = "Hello World!".encode("ascii")
+
+    with token.open(user_pin="1111") as session:
+
+        #write data into an object
+        session.create_object(
+            attrs={
+                pkcs11.Attribute.CLASS: pkcs11.ObjectClass.DATA,
+                pkcs11.Attribute.APPLICATION: demoapp,
+                pkcs11.Attribute.LABEL: demolabel,
+                pkcs11.Attribute.VALUE: demodata,
+                pkcs11.Attribute.TOKEN: True
+            })
+
+        #retrieve an object
+        objectfilter = {
+                pkcs11.Attribute.CLASS: pkcs11.ObjectClass.DATA,
+                pkcs11.Attribute.LABEL: demolabel
+        }
+
+        #objects are not uniquely identified by their attributes
+        #the result might be a list of multiple objects with "demolabel"
+        objects = list(session.get_objects(attrs=objectfilter))
+        print(objects)
+
+        #extract information from an object
+        print(objects[-1][pkcs11.Attribute.VALUE])
+
+        #change an object
+        objects[-1][pkcs11.Attribute.VALUE] = "testdata".encode("ascii")
+        print(objects[-1][pkcs11.Attribute.VALUE])
+
+
 Tested Compatibility
 --------------------
 


### PR DESCRIPTION
Just a proposal; I guess you might want to keep the documentation focused on dealing with public key crypto. Maybe it's time to make an example directory for the more obscure example scripts?
I don't see a straightforward way to add tests for this, as I don't own any of the devices that you are targeting. It'll be a while before I can test with a standard card or token.
This ObjectClass.DATA stuff is coming from me because I'm in the progress of writing a fuse fs driver capable of mounting a pkcs11 smartcard  with the goal of storing zfs disk encryption keys on there.