### PR TITLE
Changed _fix_string_length calls to instead use string slices.

### DIFF
--- a/pkcs11/_utils.pyx
+++ b/pkcs11/_utils.pyx
@@ -36,8 +36,3 @@ cdef _unpack_attributes(key, value):
     except KeyError:
         raise NotImplementedError("Can't unpack this %s. "
                                   "Expand ATTRIBUTE_TYPES!" % key)
-
-
-cdef _fix_string_length(CK_UTF8CHAR *string, size_t size):
-    """Insert NUL-bytes into strings so Python knows their length."""
-    string[size - 1] = b'\0'

--- a/tests/test_aes.py
+++ b/tests/test_aes.py
@@ -107,7 +107,6 @@ class AESTests(TestCase):
 
     @requires(Mechanism.AES_KEY_WRAP)
     @FIXME.opencryptoki  # can't set key attributes
-    @FIXME.travis  # Travis has an old OpenSSL
     def test_wrap(self):
         key = self.session.generate_key(pkcs11.KeyType.AES, 128, template={
             pkcs11.Attribute.EXTRACTABLE: True,


### PR DESCRIPTION
This fixes #63. For string fields in Slot, Token and lib, string slices are now used instead of `_fix_string_label`. 