### PR TITLE
pkcs11/_pkcs11.pyx: add support for protected authentication

### DIFF
--- a/pkcs11/_pkcs11.pyx
+++ b/pkcs11/_pkcs11.pyx
@@ -225,7 +225,7 @@ class Slot(types.Slot):
 class Token(types.Token):
     """Extend Token with implementation."""
 
-    def open(self, rw=False, user_pin=None, so_pin=None, p_auth=False):
+    def open(self, rw=False, user_pin=None, so_pin=None, use_protected_auth=False):
         cdef CK_SESSION_HANDLE handle
         cdef CK_FLAGS flags = CKF_SERIAL_SESSION
         cdef CK_USER_TYPE user_type
@@ -235,11 +235,11 @@ class Token(types.Token):
 
         if user_pin is not None and so_pin is not None:
             raise ArgumentsBad("Set either `user_pin` or `so_pin`")
-        elif user_pin is not None and use_pap:
-            raise ArgumentsBad("Set either `user_pin` or `p_auth`")
-        elif so_pin is not None and use_pap:
-            raise ArgumentsBad("Set either `so_pin` or `p_auth`")
-        elif p_auth:
+        elif user_pin is not None and use_protected_auth:
+            raise ArgumentsBad("Set either `user_pin` or `use_protected_auth`")
+        elif so_pin is not None and use_protected_auth:
+            raise ArgumentsBad("Set either `so_pin` or `use_protected_auth`")
+        elif use_protected_auth:
             pin = None
             user_type = CKU_USER
         elif user_pin is not None:
@@ -254,11 +254,11 @@ class Token(types.Token):
 
         assertRV(_funclist.C_OpenSession(self.slot.slot_id, flags, NULL, NULL, &handle))
 
-        if p_auth:
+        if use_protected_auth:
             if self.flags & TokenFlag.PROTECTED_AUTHENTICATION_PATH:
-                assertRV(_funclist.C_Login(handle, user_type, NULL, < CK_ULONG > 0))
+                assertRV(_funclist.C_Login(handle, user_type, NULL, <CK_ULONG> 0))
             else:
-                raise ArgumentsBad('Protected authentication is not supported by loaded module')
+                raise ArgumentsBad("Protected authentication is not supported by loaded module")
         elif pin is not None:
             assertRV(_funclist.C_Login(handle, user_type, pin, <CK_ULONG> len(pin)))
 

--- a/pkcs11/types.py
+++ b/pkcs11/types.py
@@ -27,6 +27,8 @@ from .exceptions import (
     SignatureLenRange,
 )
 
+PROTECTED_AUTH = object()
+"""Indicate the pin should be supplied via an external mechanism (e.g. pin pad)"""
 
 def _CK_UTF8CHAR_to_str(data):
     """Convert CK_UTF8CHAR to string."""
@@ -200,10 +202,11 @@ class Token:
     def __eq__(self, other):
         return self.slot == other.slot
 
-    def open(self, rw=False, user_pin=None, so_pin=None, use_protected_auth=False):
+    def open(self, rw=False, user_pin=None, so_pin=None):
         """
         Open a session on the token and optionally log in as a user or
-        security officer (pass one of `user_pin` or `so_pin`).
+        security officer (pass one of `user_pin` or `so_pin`). Pass PROTECTED_AUTH to
+        indicate the pin should be supplied via an external mechanism (e.g. pin pad).
 
         Can be used as a context manager or close with :meth:`Session.close`.
 
@@ -217,7 +220,6 @@ class Token:
         :param bytes user_pin: Authenticate to this session as a user.
         :param bytes so_pin: Authenticate to this session as a
             security officer.
-        :param use_protected_auth: True to use protected authentication on a token
 
         :rtype: Session
         """

--- a/pkcs11/types.py
+++ b/pkcs11/types.py
@@ -200,7 +200,7 @@ class Token:
     def __eq__(self, other):
         return self.slot == other.slot
 
-    def open(self, rw=False, user_pin=None, so_pin=None):
+    def open(self, rw=False, user_pin=None, so_pin=None, use_protected_auth=False):
         """
         Open a session on the token and optionally log in as a user or
         security officer (pass one of `user_pin` or `so_pin`).
@@ -217,6 +217,7 @@ class Token:
         :param bytes user_pin: Authenticate to this session as a user.
         :param bytes so_pin: Authenticate to this session as a
             security officer.
+        :param use_protected_auth: True to use protected authentication on a token
 
         :rtype: Session
         """


### PR DESCRIPTION
Some pkcs11 libs offer a 'protected authentication' path (CKF_PROTECTED_AUTHENTICATION_PATH) e.g. keychain-pkcs11, HID ActivClient support this feature (OpenSC does not). 
This is a useful feature so that application devs do not have to collect/manage/zero pin credentials themselves.

 It seems to make sense to add an additional boolean to the open function for developers who know they are using a library that supports protected authentication. 

