### PR TITLE
Change SignMixin to release GIL when calling C_Sign/C_SignFinal

### DIFF
--- a/pkcs11/_errors.pyx
+++ b/pkcs11/_errors.pyx
@@ -82,7 +82,7 @@ cdef ERROR_MAP = {
 }
 
 
-cpdef void assertRV(CK_RV rv) except *:
+cpdef void assertRV(CK_RV rv) nogil except *:
     """Check for an acceptable RV value or thrown an exception."""
     if rv != CKR_OK:
         raise ERROR_MAP.get(rv,

--- a/pkcs11/_pkcs11.pyx
+++ b/pkcs11/_pkcs11.pyx
@@ -928,8 +928,8 @@ class SignMixin(types.SignMixin):
             mechanism, mechanism_param)
 
         cdef CK_ULONG session_handle = self.session._handle
-        cdef CK_BYTE *data_buffer = data
-        cdef CK_ULONG data_length = len(data)
+        cdef CK_BYTE *data_ptr = data
+        cdef CK_ULONG data_len = len(data)
         cdef CK_BYTE [:] signature
         cdef CK_ULONG length
 
@@ -938,14 +938,14 @@ class SignMixin(types.SignMixin):
                                           self._handle))
 
             # Call to find out the buffer length
-            assertRV(_funclist.C_Sign(session_handle, &data_buffer[0],
-                                      data_length, NULL, &length))
+            assertRV(_funclist.C_Sign(session_handle, data_ptr, data_len,
+                                      NULL, &length))
 
             signature = CK_BYTE_buffer(length)
 
             with nogil:
-                assertRV(_funclist.C_Sign(session_handle, &data_buffer[0],
-                                          data_length, &signature[0], &length))
+                assertRV(_funclist.C_Sign(session_handle, data_ptr, data_len,
+                                          &signature[0], &length))
 
             return bytes(signature[:length])
 

--- a/pkcs11/_pkcs11.pyx
+++ b/pkcs11/_pkcs11.pyx
@@ -189,9 +189,11 @@ class Slot(types.Slot):
     """Extend Slot with implementation."""
 
     def get_token(self):
+        cdef CK_SLOT_ID slot_id = self.slot_id
         cdef CK_TOKEN_INFO info
 
-        assertRV(_funclist.C_GetTokenInfo(self.slot_id, &info))
+        with nogil:
+            assertRV(_funclist.C_GetTokenInfo(slot_id, &info))
 
         label = info.label[:sizeof(info.label)]
         serialNumber = info.serialNumber[:sizeof(info.serialNumber)]
@@ -202,23 +204,30 @@ class Slot(types.Slot):
                      info.hardwareVersion, info.firmwareVersion, info.flags)
 
     def get_mechanisms(self):
+        cdef CK_SLOT_ID slot_id = self.slot_id
         cdef CK_ULONG count
 
-        assertRV(_funclist.C_GetMechanismList(self.slot_id, NULL, &count))
+        with nogil:
+            assertRV(_funclist.C_GetMechanismList(slot_id, NULL, &count))
 
         if count == 0:
             return set()
 
         cdef CK_MECHANISM_TYPE [:] mechanisms = CK_ULONG_buffer(count)
 
-        assertRV(_funclist.C_GetMechanismList(self.slot_id, &mechanisms[0], &count))
+        with nogil:
+            assertRV(_funclist.C_GetMechanismList(slot_id, &mechanisms[0],
+                                                  &count))
 
         return set(map(_CK_MECHANISM_TYPE_to_enum, mechanisms))
 
     def get_mechanism_info(self, mechanism):
+        cdef CK_SLOT_ID slot_id = self.slot_id
+        cdef CK_MECHANISM_TYPE mech_type = mechanism
         cdef CK_MECHANISM_INFO info
 
-        assertRV(_funclist.C_GetMechanismInfo(self.slot_id, mechanism, &info))
+        with nogil:
+            assertRV(_funclist.C_GetMechanismInfo(slot_id, mech_type, &info))
 
         return types.MechanismInfo(self, mechanism, **info)
 
@@ -227,9 +236,12 @@ class Token(types.Token):
     """Extend Token with implementation."""
 
     def open(self, rw=False, user_pin=None, so_pin=None):
+        cdef CK_SLOT_ID slot_id = self.slot.slot_id
         cdef CK_SESSION_HANDLE handle
         cdef CK_FLAGS flags = CKF_SERIAL_SESSION
         cdef CK_USER_TYPE user_type
+        cdef CK_UTF8CHAR *pin_data
+        cdef CK_ULONG pin_length
 
         if rw:
             flags |= CKF_RW_SESSION
@@ -252,15 +264,23 @@ class Token(types.Token):
             pin = None
             user_type = UserType.NOBODY
 
-        assertRV(_funclist.C_OpenSession(self.slot.slot_id, flags, NULL, NULL, &handle))
+        with nogil:
+            assertRV(_funclist.C_OpenSession(slot_id, flags, NULL,
+                                             NULL, &handle))
 
         if so_pin is PROTECTED_AUTH or user_pin is PROTECTED_AUTH:
             if self.flags & TokenFlag.PROTECTED_AUTHENTICATION_PATH:
-                assertRV(_funclist.C_Login(handle, user_type, NULL, <CK_ULONG> 0))
+                with nogil:
+                    assertRV(_funclist.C_Login(handle, user_type, NULL, 0))
             else:
                 raise ArgumentsBad("Protected authentication is not supported by loaded module")
         elif pin is not None:
-            assertRV(_funclist.C_Login(handle, user_type, pin, <CK_ULONG> len(pin)))
+            pin_data = pin
+            pin_length = len(pin)
+
+            with nogil:
+                assertRV(_funclist.C_Login(handle, user_type,
+                                           pin_data, pin_length))
 
         return Session(self, handle, rw=rw, user_type=user_type)
 
@@ -274,25 +294,32 @@ class SearchIter:
         template = AttributeList(attrs)
         self.session._operation_lock.acquire()
         self._active = True
-        assertRV(_funclist.C_FindObjectsInit(self.session._handle,
-                                   template.data, template.count))
+
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_ATTRIBUTE *attr_data = template.data
+        cdef CK_ULONG attr_count = template.count
+
+        with nogil:
+            assertRV(_funclist.C_FindObjectsInit(handle, attr_data,
+                                                 attr_count))
 
     def __iter__(self):
         return self
 
     def __next__(self):
         """Get the next object."""
-        cdef CK_OBJECT_HANDLE handle
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_OBJECT_HANDLE obj
         cdef CK_ULONG count
 
-        assertRV(_funclist.C_FindObjects(self.session._handle,
-                               &handle, 1, &count))
+        with nogil:
+            assertRV(_funclist.C_FindObjects(handle, &obj, 1, &count))
 
         if count == 0:
             self._finalize()
             raise StopIteration()
         else:
-            return Object._make(self.session, handle)
+            return Object._make(self.session, obj)
 
     def __del__(self):
         """Close the search."""
@@ -300,9 +327,14 @@ class SearchIter:
 
     def _finalize(self):
         """Finish the operation."""
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+
         if self._active:
             self._active = False
-            assertRV(_funclist.C_FindObjectsFinal(self.session._handle))
+
+            with nogil:
+                assertRV(_funclist.C_FindObjectsFinal(handle))
+
             self.session._operation_lock.release()
 
 
@@ -324,21 +356,29 @@ class Session(types.Session):
     """Extend Session with implementation."""
 
     def close(self):
-        if self.user_type != UserType.NOBODY:
-            assertRV(_funclist.C_Logout(self._handle))
+        cdef CK_OBJECT_HANDLE handle = self._handle
 
-        assertRV(_funclist.C_CloseSession(self._handle))
+        if self.user_type != UserType.NOBODY:
+            with nogil:
+                assertRV(_funclist.C_Logout(handle))
+
+        with nogil:
+            assertRV(_funclist.C_CloseSession(handle))
 
     def get_objects(self, attrs=None):
         return SearchIter(self, attrs or {})
 
     def create_object(self, attrs):
+        template = AttributeList(attrs)
+
+        cdef CK_OBJECT_HANDLE handle = self._handle
+        cdef CK_ATTRIBUTE *attr_data = template.data
+        cdef CK_ULONG attr_count = template.count
         cdef CK_OBJECT_HANDLE new
 
-        template = AttributeList(attrs)
-        assertRV(_funclist.C_CreateObject(self._handle,
-                                template.data, template.count,
-                                &new))
+        with nogil:
+            assertRV(_funclist.C_CreateObject(handle, attr_data,
+                                              attr_count, &new))
 
         return Object._make(self, new)
 
@@ -377,12 +417,15 @@ class Session(types.Session):
         }
         attrs = AttributeList(merge_templates(template_, template))
 
+        cdef CK_SESSION_HANDLE handle = self._handle
+        cdef CK_MECHANISM *mech_data = mech.data
+        cdef CK_ATTRIBUTE *attr_data = attrs.data
+        cdef CK_ULONG attr_count = attrs.count
         cdef CK_OBJECT_HANDLE obj
 
-        assertRV(_funclist.C_GenerateKey(self._handle,
-                               mech.data,
-                               attrs.data, attrs.count,
-                               &obj))
+        with nogil:
+            assertRV(_funclist.C_GenerateKey(handle, mech_data, attr_data,
+                                             attr_count, &obj))
 
         return Object._make(self, obj)
 
@@ -435,12 +478,15 @@ class Session(types.Session):
 
         attrs = AttributeList(merge_templates(template_, template))
 
+        cdef CK_SESSION_HANDLE handle = self._handle
+        cdef CK_MECHANISM *mech_data = mech.data
+        cdef CK_ATTRIBUTE *attr_data = attrs.data
+        cdef CK_ULONG attr_count = attrs.count
         cdef CK_OBJECT_HANDLE key
 
-        assertRV(_funclist.C_GenerateKey(self._handle,
-                               mech.data,
-                               attrs.data, attrs.count,
-                               &key))
+        with nogil:
+            assertRV(_funclist.C_GenerateKey(handle, mech_data, attr_data,
+                                             attr_count, &key))
 
         return Object._make(self, key)
 
@@ -507,74 +553,108 @@ class Session(types.Session):
         }
         private_attrs = AttributeList(merge_templates(private_template_, private_template))
 
+        cdef CK_SESSION_HANDLE handle = self._handle
+        cdef CK_MECHANISM *mech_data = mech.data
+        cdef CK_ATTRIBUTE *public_attr_data = public_attrs.data
+        cdef CK_ULONG public_attr_count = public_attrs.count
+        cdef CK_ATTRIBUTE *private_attr_data = private_attrs.data
+        cdef CK_ULONG private_attr_count = private_attrs.count
         cdef CK_OBJECT_HANDLE public_key
         cdef CK_OBJECT_HANDLE private_key
 
-        assertRV(_funclist.C_GenerateKeyPair(self._handle,
-                                   mech.data,
-                                   public_attrs.data, public_attrs.count,
-                                   private_attrs.data, private_attrs.count,
-                                   &public_key, &private_key))
+        with nogil:
+            assertRV(_funclist.C_GenerateKeyPair(handle, mech_data,
+                                                 public_attr_data,
+                                                 public_attr_count,
+                                                 private_attr_data,
+                                                 private_attr_count,
+                                                 &public_key, &private_key))
 
         return (Object._make(self, public_key),
                 Object._make(self, private_key))
 
     def seed_random(self, seed):
-        assertRV(_funclist.C_SeedRandom(self._handle, seed, <CK_ULONG> len(seed)))
+        cdef CK_SESSION_HANDLE handle = self._handle
+        cdef CK_BYTE *seed_data = seed.data
+        cdef CK_ULONG seed_len = len(seed)
+
+        with nogil:
+            assertRV(_funclist.C_SeedRandom(handle, seed_data, seed_len))
 
     def generate_random(self, nbits):
-        length = nbits // 8
-
+        cdef CK_SESSION_HANDLE handle = self._handle
+        cdef CK_ULONG length = nbits // 8
         cdef CK_CHAR [:] random = CK_BYTE_buffer(length)
 
-        assertRV(_funclist.C_GenerateRandom(self._handle, &random[0], length))
+        with nogil:
+            assertRV(_funclist.C_GenerateRandom(handle, &random[0], length))
 
         return bytes(random)
 
     def _digest(self, data, mechanism=None, mechanism_param=None):
-
         mech = MechanismWithParam(None, {}, mechanism, mechanism_param)
 
+        cdef CK_SESSION_HANDLE handle = self._handle
+        cdef CK_MECHANISM *mech_data = mech.data
+        cdef CK_BYTE *data_ptr = data
+        cdef CK_ULONG data_len = len(data)
         cdef CK_BYTE [:] digest
         cdef CK_ULONG length
 
         with self._operation_lock:
-            assertRV(_funclist.C_DigestInit(self._handle, mech.data))
+            with nogil:
+                assertRV(_funclist.C_DigestInit(handle, mech_data))
 
-            # Run once to get the length
-            assertRV(_funclist.C_Digest(self._handle,
-                              data, <CK_ULONG> len(data),
-                              NULL, &length))
+                # Run once to get the length
+                assertRV(_funclist.C_Digest(handle, data_ptr, data_len,
+                                            NULL, &length))
 
             digest = CK_BYTE_buffer(length)
 
-            assertRV(_funclist.C_Digest(self._handle,
-                              data, <CK_ULONG> len(data),
-                              &digest[0], &length))
+            with nogil:
+                assertRV(_funclist.C_Digest(handle, data_ptr, data_len,
+                                            &digest[0], &length))
 
             return bytes(digest[:length])
 
     def _digest_generator(self, data, mechanism=None, mechanism_param=None):
         mech = MechanismWithParam(None, {}, mechanism, mechanism_param)
 
+        cdef CK_SESSION_HANDLE handle = self._handle
+        cdef CK_MECHANISM *mech_data = mech.data
+        cdef CK_OBJECT_HANDLE key
+        cdef CK_BYTE *data_ptr
+        cdef CK_ULONG data_len
         cdef CK_BYTE [:] digest
         cdef CK_ULONG length
 
         with self._operation_lock:
-            assertRV(_funclist.C_DigestInit(self._handle, mech.data))
+            with nogil:
+                assertRV(_funclist.C_DigestInit(handle, mech_data))
 
             for block in data:
                 if isinstance(block, types.Key):
-                    assertRV(_funclist.C_DigestKey(self._handle, block._handle))
+                    key = block._handle
+
+                    with nogil:
+                        assertRV(_funclist.C_DigestKey(handle, key))
                 else:
-                    assertRV(_funclist.C_DigestUpdate(self._handle, block, <CK_ULONG> len(block)))
+                    data_ptr = block
+                    data_len = len(block)
+
+                    with nogil:
+                        assertRV(_funclist.C_DigestUpdate(handle, data_ptr,
+                                                          data_len))
 
             # Run once to get the length
-            assertRV(_funclist.C_DigestFinal(self._handle, NULL, &length))
+            with nogil:
+                assertRV(_funclist.C_DigestFinal(handle, NULL, &length))
 
             digest = CK_BYTE_buffer(length)
 
-            assertRV(_funclist.C_DigestFinal(self._handle, &digest[0], &length))
+            with nogil:
+                assertRV(_funclist.C_DigestFinal(handle, &digest[0],
+                                                 &length))
 
             return bytes(digest[:length])
 
@@ -627,14 +707,17 @@ class Object(types.Object):
             return self
 
     def __getitem__(self, key):
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_OBJECT_HANDLE obj = self._handle
         cdef CK_ATTRIBUTE template
+
         template.type = key
         template.pValue = NULL
         template.ulValueLen = <CK_ULONG> 0
 
         # Find out the attribute size
-        assertRV(_funclist.C_GetAttributeValue(self.session._handle, self._handle,
-                                     &template, 1))
+        with nogil:
+            assertRV(_funclist.C_GetAttributeValue(handle, obj, &template, 1))
 
         if template.ulValueLen == 0:
             return _unpack_attributes(key, b'')
@@ -644,34 +727,46 @@ class Object(types.Object):
         template.pValue = <CK_CHAR *> &value[0]
 
         # Request the value
-        assertRV(_funclist.C_GetAttributeValue(self.session._handle, self._handle,
-                                     &template, 1))
+        with nogil:
+            assertRV(_funclist.C_GetAttributeValue(handle, obj, &template, 1))
 
         return _unpack_attributes(key, value)
 
     def __setitem__(self, key, value):
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_OBJECT_HANDLE obj = self._handle
+        cdef CK_ATTRIBUTE template
+
         value = _pack_attribute(key, value)
 
-        cdef CK_ATTRIBUTE template
         template.type = key
         template.pValue = <CK_CHAR *> value
         template.ulValueLen = <CK_ULONG>len(value)
 
-        assertRV(_funclist.C_SetAttributeValue(self.session._handle, self._handle,
-                                     &template, 1))
+        with nogil:
+            assertRV(_funclist.C_SetAttributeValue(handle, obj, &template, 1))
 
     def copy(self, attrs):
+        template = AttributeList(attrs)
+
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_OBJECT_HANDLE obj = self._handle
+        cdef CK_ATTRIBUTE *attr_data = template.data
+        cdef CK_ULONG attr_count = template.count
         cdef CK_OBJECT_HANDLE new
 
-        template = AttributeList(attrs)
-        assertRV(_funclist.C_CopyObject(self.session._handle, self._handle,
-                              template.data, template.count,
-                              &new))
+        with nogil:
+            assertRV(_funclist.C_CopyObject(handle, obj, attr_data,
+                                            attr_count, &new))
 
         return Object._make(self.session, new)
 
     def destroy(self):
-        assertRV(_funclist.C_DestroyObject(self.session._handle, self._handle))
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_OBJECT_HANDLE obj = self._handle
+
+        with nogil:
+            assertRV(_funclist.C_DestroyObject(handle, obj))
 
 
 class SecretKey(types.SecretKey):
@@ -747,14 +842,22 @@ class DomainParameters(types.DomainParameters):
         }
         private_attrs = AttributeList(merge_templates(private_template_, private_template))
 
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_MECHANISM *mech_data = mech.data
+        cdef CK_ATTRIBUTE *public_attr_data = public_attrs.data
+        cdef CK_ULONG public_attr_count = public_attrs.count
+        cdef CK_ATTRIBUTE *private_attr_data = private_attrs.data
+        cdef CK_ULONG private_attr_count = private_attrs.count
         cdef CK_OBJECT_HANDLE public_key
         cdef CK_OBJECT_HANDLE private_key
 
-        assertRV(_funclist.C_GenerateKeyPair(self.session._handle,
-                                   mech.data,
-                                   public_attrs.data, public_attrs.count,
-                                   private_attrs.data, private_attrs.count,
-                                   &public_key, &private_key))
+        with nogil:
+            assertRV(_funclist.C_GenerateKeyPair(handle, mech_data,
+                                                 public_attr_data,
+                                                 public_attr_count,
+                                                 private_attr_data,
+                                                 private_attr_count,
+                                                 &public_key, &private_key))
 
         return (Object._make(self.session, public_key),
                 Object._make(self.session, private_key))
@@ -776,23 +879,28 @@ class EncryptMixin(types.EncryptMixin):
             self.key_type, DEFAULT_ENCRYPT_MECHANISMS,
             mechanism, mechanism_param)
 
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_MECHANISM *mech_data = mech.data
+        cdef CK_OBJECT_HANDLE key = self._handle
+        cdef CK_BYTE *data_ptr = data
+        cdef CK_ULONG data_len = len(data)
         cdef CK_BYTE [:] ciphertext
         cdef CK_ULONG length
 
         with self.session._operation_lock:
-            assertRV(_funclist.C_EncryptInit(self.session._handle,
-                                   mech.data, self._handle))
+            with nogil:
+                assertRV(_funclist.C_EncryptInit(handle, mech_data, key))
 
             # Call to find out the buffer length
-            assertRV(_funclist.C_Encrypt(self.session._handle,
-                               data, <CK_ULONG> len(data),
-                               NULL, &length))
+            with nogil:
+                assertRV(_funclist.C_Encrypt(handle, data_ptr, data_len,
+                                             NULL, &length))
 
             ciphertext = CK_BYTE_buffer(length)
 
-            assertRV(_funclist.C_Encrypt(self.session._handle,
-                               data, <CK_ULONG> len(data),
-                               &ciphertext[0], &length))
+            with nogil:
+                assertRV(_funclist.C_Encrypt(handle, data_ptr, data_len,
+                                             &ciphertext[0], &length))
 
             return bytes(ciphertext[:length])
 
@@ -814,29 +922,40 @@ class EncryptMixin(types.EncryptMixin):
             self.key_type, DEFAULT_ENCRYPT_MECHANISMS,
             mechanism, mechanism_param)
 
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_MECHANISM *mech_data = mech.data
+        cdef CK_OBJECT_HANDLE key = self._handle
+        cdef CK_BYTE *data_ptr = data
+        cdef CK_ULONG data_len = len(data)
         cdef CK_ULONG length
         cdef CK_BYTE [:] part_out = CK_BYTE_buffer(buffer_size)
 
         with self.session._operation_lock:
-            assertRV(_funclist.C_EncryptInit(self.session._handle,
-                                   mech.data, self._handle))
+            with nogil:
+                assertRV(_funclist.C_EncryptInit(handle, mech_data, key))
 
             for part_in in data:
                 if not part_in:
                     continue
 
+                data_ptr = part_in
+                data_len = len(part_in)
                 length = buffer_size
-                assertRV(_funclist.C_EncryptUpdate(self.session._handle,
-                                        part_in, <CK_ULONG> len(part_in),
-                                        &part_out[0], &length))
+
+                with nogil:
+                    assertRV(_funclist.C_EncryptUpdate(handle, data_ptr,
+                                                       data_len, &part_out[0],
+                                                       &length))
 
                 yield bytes(part_out[:length])
 
             # Finalize
             # We assume the buffer is much bigger than the block size
             length = buffer_size
-            assertRV(_funclist.C_EncryptFinal(self.session._handle,
-                                    &part_out[0], &length))
+
+            with nogil:
+                assertRV(_funclist.C_EncryptFinal(handle, &part_out[0],
+                                                  &length))
 
             yield bytes(part_out[:length])
 
@@ -851,23 +970,28 @@ class DecryptMixin(types.DecryptMixin):
             self.key_type, DEFAULT_ENCRYPT_MECHANISMS,
             mechanism, mechanism_param)
 
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_MECHANISM *mech_data = mech.data
+        cdef CK_OBJECT_HANDLE key = self._handle
+        cdef CK_BYTE *data_ptr = data
+        cdef CK_ULONG data_len = len(data)
         cdef CK_BYTE [:] plaintext
         cdef CK_ULONG length
 
         with self.session._operation_lock:
-            assertRV(_funclist.C_DecryptInit(self.session._handle,
-                                   mech.data, self._handle))
+            with nogil:
+                assertRV(_funclist.C_DecryptInit(handle, mech_data, key))
 
             # Call to find out the buffer length
-            assertRV(_funclist.C_Decrypt(self.session._handle,
-                               data, <CK_ULONG> len(data),
-                               NULL, &length))
+            with nogil:
+                assertRV(_funclist.C_Decrypt(handle, data_ptr, data_len,
+                                             NULL, &length))
 
             plaintext = CK_BYTE_buffer(length)
 
-            assertRV(_funclist.C_Decrypt(self.session._handle,
-                               data, <CK_ULONG> len(data),
-                               &plaintext[0], &length))
+            with nogil:
+                assertRV(_funclist.C_Decrypt(handle, data_ptr, data_len,
+                                             &plaintext[0], &length))
 
             return bytes(plaintext[:length])
 
@@ -889,30 +1013,40 @@ class DecryptMixin(types.DecryptMixin):
             self.key_type, DEFAULT_ENCRYPT_MECHANISMS,
             mechanism, mechanism_param)
 
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_MECHANISM *mech_data = mech.data
+        cdef CK_OBJECT_HANDLE key = self._handle
+        cdef CK_BYTE *data_ptr
+        cdef CK_ULONG data_len
         cdef CK_ULONG length
         cdef CK_BYTE [:] part_out = CK_BYTE_buffer(buffer_size)
 
         with self.session._operation_lock:
-            assertRV(_funclist.C_DecryptInit(self.session._handle,
-                                   mech.data, self._handle))
+            with nogil:
+                assertRV(_funclist.C_DecryptInit(handle, mech_data, key))
 
             for part_in in data:
                 if not part_in:
                     continue
 
+                data_ptr = part_in
+                data_len = len(part_in)
                 length = buffer_size
 
-                assertRV(_funclist.C_DecryptUpdate(self.session._handle,
-                                        part_in, <CK_ULONG> len(part_in),
-                                        &part_out[0], &length))
+                with nogil:
+                    assertRV(_funclist.C_DecryptUpdate(handle, data_ptr,
+                                                       data_len, &part_out[0],
+                                                       &length))
 
                 yield bytes(part_out[:length])
 
             # Finalize
             # We assume the buffer is much bigger than the block size
             length = buffer_size
-            assertRV(_funclist.C_DecryptFinal(self.session._handle,
-                                    &part_out[0], &length))
+
+            with nogil:
+                assertRV(_funclist.C_DecryptFinal(handle, &part_out[0],
+                                                  &length))
 
             yield bytes(part_out[:length])
 
@@ -927,24 +1061,26 @@ class SignMixin(types.SignMixin):
             self.key_type, DEFAULT_SIGN_MECHANISMS,
             mechanism, mechanism_param)
 
-        cdef CK_ULONG session_handle = self.session._handle
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_MECHANISM *mech_data = mech.data
+        cdef CK_OBJECT_HANDLE key = self._handle
         cdef CK_BYTE *data_ptr = data
         cdef CK_ULONG data_len = len(data)
         cdef CK_BYTE [:] signature
         cdef CK_ULONG length
 
         with self.session._operation_lock:
-            assertRV(_funclist.C_SignInit(session_handle, mech.data,
-                                          self._handle))
+            with nogil:
+                assertRV(_funclist.C_SignInit(handle, mech_data, key))
 
-            # Call to find out the buffer length
-            assertRV(_funclist.C_Sign(session_handle, data_ptr, data_len,
-                                      NULL, &length))
+                # Call to find out the buffer length
+                assertRV(_funclist.C_Sign(handle, data_ptr, data_len,
+                                          NULL, &length))
 
             signature = CK_BYTE_buffer(length)
 
             with nogil:
-                assertRV(_funclist.C_Sign(session_handle, data_ptr, data_len,
+                assertRV(_funclist.C_Sign(handle, data_ptr, data_len,
                                           &signature[0], &length))
 
             return bytes(signature[:length])
@@ -956,30 +1092,37 @@ class SignMixin(types.SignMixin):
             self.key_type, DEFAULT_SIGN_MECHANISMS,
             mechanism, mechanism_param)
 
-        cdef CK_ULONG session_handle = self.session._handle
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_MECHANISM *mech_data = mech.data
+        cdef CK_OBJECT_HANDLE key = self._handle
+        cdef CK_BYTE *data_ptr
+        cdef CK_ULONG data_len
         cdef CK_BYTE [:] signature
         cdef CK_ULONG length
 
         with self.session._operation_lock:
-            assertRV(_funclist.C_SignInit(session_handle, mech.data,
-                                          self._handle))
+            with nogil:
+                assertRV(_funclist.C_SignInit(handle, mech_data, key))
 
             for part_in in data:
                 if not part_in:
                     continue
 
-                assertRV(_funclist.C_SignUpdate(self.session._handle,
-                                      part_in, <CK_ULONG> len(part_in)))
+                data_ptr = part_in
+                data_len = len(part_in)
+
+                with nogil:
+                    assertRV(_funclist.C_SignUpdate(handle, data_ptr, data_len))
 
             # Finalize
             # Call to find out the buffer length
-            assertRV(_funclist.C_SignFinal(session_handle, NULL, &length))
+            with nogil:
+                assertRV(_funclist.C_SignFinal(handle, NULL, &length))
 
             signature = CK_BYTE_buffer(length)
 
             with nogil:
-                assertRV(_funclist.C_SignFinal(session_handle,
-                                               &signature[0], &length))
+                assertRV(_funclist.C_SignFinal(handle, &signature[0], &length))
 
             return bytes(signature[:length])
 
@@ -994,14 +1137,20 @@ class VerifyMixin(types.VerifyMixin):
             self.key_type, DEFAULT_SIGN_MECHANISMS,
             mechanism, mechanism_param)
 
-        with self.session._operation_lock:
-            assertRV(_funclist.C_VerifyInit(self.session._handle,
-                                  mech.data, self._handle))
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_MECHANISM *mech_data = mech.data
+        cdef CK_OBJECT_HANDLE key = self._handle
+        cdef CK_BYTE *data_ptr = data
+        cdef CK_ULONG data_len = len(data)
+        cdef CK_BYTE *sig_ptr = signature
+        cdef CK_ULONG sig_len = len(signature)
 
-            # Call to find out the buffer length
-            assertRV(_funclist.C_Verify(self.session._handle,
-                              data, <CK_ULONG> len(data),
-                              signature, <CK_ULONG> len(signature)))
+        with self.session._operation_lock:
+            with nogil:
+                assertRV(_funclist.C_VerifyInit(handle, mech_data, key))
+
+                assertRV(_funclist.C_Verify(handle, data_ptr, data_len,
+                                            sig_ptr, sig_len))
 
     def _verify_generator(self, data, signature,
                           mechanism=None, mechanism_param=None):
@@ -1010,20 +1159,31 @@ class VerifyMixin(types.VerifyMixin):
             self.key_type, DEFAULT_SIGN_MECHANISMS,
             mechanism, mechanism_param)
 
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_MECHANISM *mech_data = mech.data
+        cdef CK_OBJECT_HANDLE key = self._handle
+        cdef CK_BYTE *data_ptr
+        cdef CK_ULONG data_len
+        cdef CK_BYTE *sig_ptr = signature
+        cdef CK_ULONG sig_len = len(signature)
+
         with self.session._operation_lock:
-            assertRV(_funclist.C_VerifyInit(self.session._handle,
-                                  mech.data, self._handle))
+            with nogil:
+                assertRV(_funclist.C_VerifyInit(handle, mech_data, key))
 
             for part_in in data:
                 if not part_in:
                     continue
 
-                assertRV(_funclist.C_VerifyUpdate(self.session._handle,
-                                        part_in, <CK_ULONG> len(part_in)))
+                data_ptr = part_in
+                data_len = len(part_in)
 
+                with nogil:
+                    assertRV(_funclist.C_VerifyUpdate(handle, data_ptr,
+                                                      data_len))
 
-            assertRV(_funclist.C_VerifyFinal(self.session._handle,
-                                   signature, <CK_ULONG> len(signature)))
+            with nogil:
+                assertRV(_funclist.C_VerifyFinal(handle, sig_ptr, sig_len))
 
 
 class WrapMixin(types.WrapMixin):
@@ -1039,22 +1199,22 @@ class WrapMixin(types.WrapMixin):
             self.key_type, DEFAULT_WRAP_MECHANISMS,
             mechanism, mechanism_param)
 
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_MECHANISM *mech_data = mech.data
+        cdef CK_OBJECT_HANDLE wrapping_key = self._handle
+        cdef CK_OBJECT_HANDLE key_to_wrap = key._handle
         cdef CK_ULONG length
 
         # Find out how many bytes we need to allocate
-        assertRV(_funclist.C_WrapKey(self.session._handle,
-                           mech.data,
-                           self._handle,
-                           key._handle,
-                           NULL, &length))
+        with nogil:
+            assertRV(_funclist.C_WrapKey(handle, mech_data, wrapping_key,
+                                         key_to_wrap, NULL, &length))
 
         cdef CK_BYTE [:] data = CK_BYTE_buffer(length)
 
-        assertRV(_funclist.C_WrapKey(self.session._handle,
-                           mech.data,
-                           self._handle,
-                           key._handle,
-                           &data[0], &length))
+        with nogil:
+            assertRV(_funclist.C_WrapKey(handle, mech_data, wrapping_key,
+                                         key_to_wrap, &data[0], &length))
 
         return bytes(data[:length])
 
@@ -1103,14 +1263,19 @@ class UnwrapMixin(types.UnwrapMixin):
         }
         attrs = AttributeList(merge_templates(template_, template))
 
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_MECHANISM *mech_data = mech.data
+        cdef CK_OBJECT_HANDLE unwrapping_key = self._handle
+        cdef CK_BYTE *wrapped_key_ptr = key_data
+        cdef CK_ULONG wrapped_key_len = len(key_data)
+        cdef CK_ATTRIBUTE *attr_data = attrs.data
+        cdef CK_ULONG attr_count = attrs.count
         cdef CK_OBJECT_HANDLE key
 
-        assertRV(_funclist.C_UnwrapKey(self.session._handle,
-                             mech.data,
-                             self._handle,
-                             key_data, <CK_ULONG> len(key_data),
-                             attrs.data, attrs.count,
-                             &key))
+        with nogil:
+            assertRV(_funclist.C_UnwrapKey(handle, mech_data, unwrapping_key,
+                                           wrapped_key_ptr, wrapped_key_len,
+                                           attr_data, attr_count, &key))
 
         return Object._make(self.session, key)
 
@@ -1162,13 +1327,16 @@ class DeriveMixin(types.DeriveMixin):
         }
         attrs = AttributeList(merge_templates(template_, template))
 
+        cdef CK_SESSION_HANDLE handle = self.session._handle
+        cdef CK_MECHANISM *mech_data = mech.data
+        cdef CK_OBJECT_HANDLE src_key = self._handle
+        cdef CK_ATTRIBUTE *attr_data = attrs.data
+        cdef CK_ULONG attr_count = attrs.count
         cdef CK_OBJECT_HANDLE key
 
-        assertRV(_funclist.C_DeriveKey(self.session._handle,
-                             mech.data,
-                             self._handle,
-                             attrs.data, attrs.count,
-                             &key))
+        with nogil:
+            assertRV(_funclist.C_DeriveKey(handle, mech_data, src_key,
+                                           attr_data, attr_count, &key))
 
         return Object._make(self.session, key)
 
@@ -1237,7 +1405,8 @@ cdef class lib:
             if C_GetFunctionList == NULL:
                 raise RuntimeError("{} is not a PKCS#11 library: {}".format(so, dlfcn.dlerror()))
 
-        assertRV(C_GetFunctionList(&_funclist))
+        with nogil:
+            assertRV(C_GetFunctionList(&_funclist))
 
 
     cdef _unload_pkcs11_lib(self) with gil:
@@ -1259,12 +1428,15 @@ cdef class lib:
     def __cinit__(self, so):
         self._load_pkcs11_lib(so)
         # at this point, _funclist contains all function pointers to the library
-        assertRV(_funclist.C_Initialize(NULL))
+        with nogil:
+            assertRV(_funclist.C_Initialize(NULL))
 
     def __init__(self, so):
         self.so = so
         cdef CK_INFO info
-        assertRV(_funclist.C_GetInfo(&info))
+
+        with nogil:
+            assertRV(_funclist.C_GetInfo(&info))
 
         manufacturerID = info.manufacturerID[:sizeof(info.manufacturerID)]
         libraryDescription = info.libraryDescription[:sizeof(info.libraryDescription)]
@@ -1291,28 +1463,34 @@ cdef class lib:
     def get_slots(self, token_present=False):
         """Get all slots."""
 
+        cdef CK_BBOOL present = token_present
         cdef CK_ULONG count
 
-        assertRV(_funclist.C_GetSlotList(token_present, NULL, &count))
+        with nogil:
+            assertRV(_funclist.C_GetSlotList(present, NULL, &count))
 
         if count == 0:
             return []
 
-        cdef CK_ULONG [:] slotIDs = CK_ULONG_buffer(count)
+        cdef CK_SLOT_ID [:] slot_list = CK_ULONG_buffer(count)
 
-        assertRV(_funclist.C_GetSlotList(token_present, &slotIDs[0], &count))
+        with nogil:
+            assertRV(_funclist.C_GetSlotList(present, &slot_list[0], &count))
 
+        cdef CK_SLOT_ID slot_id
         cdef CK_SLOT_INFO info
+
         slots = []
 
-        for slotID in slotIDs:
-            assertRV(_funclist.C_GetSlotInfo(slotID, &info))
+        for slot_id in slot_list:
+            with nogil:
+                assertRV(_funclist.C_GetSlotInfo(slot_id, &info))
 
             slotDescription = info.slotDescription[:sizeof(info.slotDescription)]
             manufacturerID = info.manufacturerID[:sizeof(info.manufacturerID)]
 
             slots.append(
-                Slot(self, slotID, slotDescription, manufacturerID,
+                Slot(self, slot_id, slotDescription, manufacturerID,
                      info.hardwareVersion, info.firmwareVersion, info.flags)
             )
 
@@ -1374,11 +1552,13 @@ cdef class lib:
 
     def reinitialize(self):
         if _funclist != NULL:
-            assertRV(_funclist.C_Finalize(NULL))
-            assertRV(_funclist.C_Initialize(NULL))
+            with nogil:
+                assertRV(_funclist.C_Finalize(NULL))
+                assertRV(_funclist.C_Initialize(NULL))
 
     def __dealloc__(self):
         if _funclist != NULL:
-            assertRV(_funclist.C_Finalize(NULL))
+            with nogil:
+                assertRV(_funclist.C_Finalize(NULL))
 
         self._unload_pkcs11_lib()

--- a/pkcs11/_pkcs11.pyx
+++ b/pkcs11/_pkcs11.pyx
@@ -575,7 +575,7 @@ class Session(types.Session):
 
     def seed_random(self, seed):
         cdef CK_SESSION_HANDLE handle = self._handle
-        cdef CK_BYTE *seed_data = seed.data
+        cdef CK_BYTE *seed_data = seed
         cdef CK_ULONG seed_len = len(seed)
 
         with nogil:
@@ -925,8 +925,8 @@ class EncryptMixin(types.EncryptMixin):
         cdef CK_SESSION_HANDLE handle = self.session._handle
         cdef CK_MECHANISM *mech_data = mech.data
         cdef CK_OBJECT_HANDLE key = self._handle
-        cdef CK_BYTE *data_ptr = data
-        cdef CK_ULONG data_len = len(data)
+        cdef CK_BYTE *data_ptr
+        cdef CK_ULONG data_len
         cdef CK_ULONG length
         cdef CK_BYTE [:] part_out = CK_BYTE_buffer(buffer_size)
 

--- a/pkcs11/_pkcs11_defn.pxd
+++ b/pkcs11/_pkcs11_defn.pxd
@@ -248,185 +248,185 @@ cdef extern from '../extern/cryptoki.h':
         ## caution: order matters!
 
         ## general purpose
-        CK_RV C_Initialize(void *)
+        CK_RV C_Initialize(void *) nogil
 
-        CK_RV C_Finalize(void *)
+        CK_RV C_Finalize(void *) nogil
 
-        CK_RV C_GetInfo(CK_INFO *info)
+        CK_RV C_GetInfo(CK_INFO *info) nogil
 
-        CK_RV C_GetFunctionList(CK_FUNCTION_LIST **)
+        CK_RV C_GetFunctionList(CK_FUNCTION_LIST **) nogil
 
         ## slot and token management
         CK_RV C_GetSlotList(CK_BBOOL tokenPresent,
                             CK_SLOT_ID *slotList,
-                            CK_ULONG *count)
+                            CK_ULONG *count) nogil
 
         CK_RV C_GetSlotInfo(CK_SLOT_ID slotID,
-                            CK_SLOT_INFO *info)
+                            CK_SLOT_INFO *info) nogil
 
         CK_RV C_GetTokenInfo(CK_SLOT_ID slotID,
-                             CK_TOKEN_INFO *info)
+                             CK_TOKEN_INFO *info) nogil
 
         CK_RV C_GetMechanismList(CK_SLOT_ID slotID,
                                  CK_MECHANISM_TYPE *mechanismList,
-                                 CK_ULONG *count)
+                                 CK_ULONG *count) nogil
 
         CK_RV C_GetMechanismInfo(CK_SLOT_ID slotID,
                                  CK_MECHANISM_TYPE mechanism,
-                                 CK_MECHANISM_INFO *info)
+                                 CK_MECHANISM_INFO *info) nogil
 
         CK_RV C_InitToken(CK_SLOT_ID slotID,
                           CK_UTF8CHAR *pPin,
                           CK_ULONG ulPinLen,
-                          CK_UTF8CHAR *pLabel)
+                          CK_UTF8CHAR *pLabel) nogil
 
         CK_RV C_InitPIN(CK_SESSION_HANDLE hSession,
                         CK_UTF8CHAR *pPin,
-                        CK_ULONG ulPinLen)
+                        CK_ULONG ulPinLen) nogil
 
         CK_RV C_SetPIN(CK_SESSION_HANDLE hSession,
                        CK_UTF8CHAR *pOldPin,
                        CK_ULONG ulOldLen,
                        CK_UTF8CHAR *pNewPin,
-                       CK_ULONG ulNewLen)
+                       CK_ULONG ulNewLen) nogil
 
         ## session management
         CK_RV C_OpenSession(CK_SLOT_ID slotID,
                             CK_FLAGS flags,
                             void *application,
                             void *notify,
-                            CK_SESSION_HANDLE *handle)
+                            CK_SESSION_HANDLE *handle) nogil
 
-        CK_RV C_CloseSession(CK_SESSION_HANDLE session)
+        CK_RV C_CloseSession(CK_SESSION_HANDLE session) nogil
 
-        CK_RV C_CloseAllSessions(CK_SLOT_ID slotID)
+        CK_RV C_CloseAllSessions(CK_SLOT_ID slotID) nogil
 
         CK_RV C_GetSessionInfo(CK_SESSION_HANDLE hSession,
-                               CK_SESSION_INFO *pInfo)
+                               CK_SESSION_INFO *pInfo) nogil
 
         CK_RV C_GetOperationState(CK_SESSION_HANDLE hSession,
                                   CK_BYTE *pOperationState,
-                                  CK_ULONG *pulOperationStateLen)
+                                  CK_ULONG *pulOperationStateLen) nogil
 
         CK_RV C_SetOperationState(CK_SESSION_HANDLE hSession,
                                   CK_BYTE *pOperationState,
                                   CK_ULONG ulOperationStateLen,
                                   CK_OBJECT_HANDLE hEncryptionKey,
-                                  CK_OBJECT_HANDLE hAuthenticationKey)
+                                  CK_OBJECT_HANDLE hAuthenticationKey) nogil
 
         CK_RV C_Login(CK_SESSION_HANDLE session,
                       CK_USER_TYPE userType,
                       CK_UTF8CHAR *pin,
-                      CK_ULONG pinLen)
+                      CK_ULONG pinLen) nogil
 
-        CK_RV C_Logout(CK_SESSION_HANDLE session)
+        CK_RV C_Logout(CK_SESSION_HANDLE session) nogil
 
         ## object management
         CK_RV C_CreateObject(CK_SESSION_HANDLE session,
                              CK_ATTRIBUTE *template,
                              CK_ULONG count,
-                             CK_OBJECT_HANDLE *key)
+                             CK_OBJECT_HANDLE *key) nogil
 
         CK_RV C_CopyObject(CK_SESSION_HANDLE session,
                            CK_OBJECT_HANDLE key,
                            CK_ATTRIBUTE *template,
                            CK_ULONG count,
-                           CK_OBJECT_HANDLE *new_key)
+                           CK_OBJECT_HANDLE *new_key) nogil
 
         CK_RV C_DestroyObject(CK_SESSION_HANDLE session,
-                              CK_OBJECT_HANDLE key)
+                              CK_OBJECT_HANDLE key) nogil
 
         CK_RV C_GetObjectSize(CK_SESSION_HANDLE hSession,
                               CK_OBJECT_HANDLE hObject,
-                              CK_ULONG *pulSize)
+                              CK_ULONG *pulSize) nogil
 
         CK_RV C_GetAttributeValue(CK_SESSION_HANDLE session,
                                   CK_OBJECT_HANDLE key,
                                   CK_ATTRIBUTE *template,
-                                  CK_ULONG count)
+                                  CK_ULONG count) nogil
 
         CK_RV C_SetAttributeValue(CK_SESSION_HANDLE session,
                                   CK_OBJECT_HANDLE key,
                                   CK_ATTRIBUTE *template,
-                                  CK_ULONG count)
+                                  CK_ULONG count) nogil
 
         CK_RV C_FindObjectsInit(CK_SESSION_HANDLE session,
                                 CK_ATTRIBUTE *template,
-                                CK_ULONG count)
+                                CK_ULONG count) nogil
 
         CK_RV C_FindObjects(CK_SESSION_HANDLE session,
                             CK_OBJECT_HANDLE *objects,
                             CK_ULONG objectsMax,
-                            CK_ULONG *objectsLength)
+                            CK_ULONG *objectsLength) nogil
 
-        CK_RV C_FindObjectsFinal(CK_SESSION_HANDLE session)
+        CK_RV C_FindObjectsFinal(CK_SESSION_HANDLE session) nogil
 
         ## encryption and decryption
         CK_RV C_EncryptInit(CK_SESSION_HANDLE session,
                             CK_MECHANISM *mechanism,
-                            CK_OBJECT_HANDLE key)
+                            CK_OBJECT_HANDLE key) nogil
 
         CK_RV C_Encrypt(CK_SESSION_HANDLE session,
                         CK_BYTE *plaintext,
                         CK_ULONG plaintext_len,
                         CK_BYTE *ciphertext,
-                        CK_ULONG *ciphertext_len)
+                        CK_ULONG *ciphertext_len) nogil
 
         CK_RV C_EncryptUpdate(CK_SESSION_HANDLE session,
                               CK_BYTE *part_in,
                               CK_ULONG part_in_len,
                               CK_BYTE *part_out,
-                              CK_ULONG *part_out_len)
+                              CK_ULONG *part_out_len) nogil
 
         CK_RV C_EncryptFinal(CK_SESSION_HANDLE session,
                              CK_BYTE *part_out,
-                             CK_ULONG *part_out_len)
+                             CK_ULONG *part_out_len) nogil
 
         CK_RV C_DecryptInit(CK_SESSION_HANDLE session,
                             CK_MECHANISM *mechanism,
-                            CK_OBJECT_HANDLE key)
+                            CK_OBJECT_HANDLE key) nogil
 
         CK_RV C_Decrypt(CK_SESSION_HANDLE session,
                         CK_BYTE *ciphertext,
                         CK_ULONG ciphertext_len,
                         CK_BYTE *plaintext,
-                        CK_ULONG *plaintext_len)
+                        CK_ULONG *plaintext_len) nogil
 
         CK_RV C_DecryptUpdate(CK_SESSION_HANDLE session,
                               CK_BYTE *part_in,
                               CK_ULONG part_in_len,
                               CK_BYTE *part_out,
-                              CK_ULONG *part_out_len)
+                              CK_ULONG *part_out_len) nogil
 
         CK_RV C_DecryptFinal(CK_SESSION_HANDLE session,
                              CK_BYTE *part_out,
-                             CK_ULONG *part_out_len)
+                             CK_ULONG *part_out_len) nogil
 
         ## Message digests
         CK_RV C_DigestInit(CK_SESSION_HANDLE session,
-                           CK_MECHANISM *mechanism)
+                           CK_MECHANISM *mechanism) nogil
 
         CK_RV C_Digest(CK_SESSION_HANDLE session,
                        CK_BYTE *data,
                        CK_ULONG data_len,
                        CK_BYTE *digest,
-                       CK_ULONG *digest_len)
+                       CK_ULONG *digest_len) nogil
 
         CK_RV C_DigestUpdate(CK_SESSION_HANDLE session,
                              CK_BYTE *data,
-                             CK_ULONG data_len)
+                             CK_ULONG data_len) nogil
 
         CK_RV C_DigestKey(CK_SESSION_HANDLE session,
-                          CK_OBJECT_HANDLE key)
+                          CK_OBJECT_HANDLE key) nogil
 
         CK_RV C_DigestFinal(CK_SESSION_HANDLE session,
                             CK_BYTE *digest,
-                            CK_ULONG *digest_len)
+                            CK_ULONG *digest_len) nogil
 
         ## Signing and MACing
         CK_RV C_SignInit(CK_SESSION_HANDLE session,
                          CK_MECHANISM *mechanism,
-                         CK_OBJECT_HANDLE key)
+                         CK_OBJECT_HANDLE key) nogil
 
         CK_RV C_Sign(CK_SESSION_HANDLE session,
                      CK_BYTE *text,
@@ -436,7 +436,7 @@ cdef extern from '../extern/cryptoki.h':
 
         CK_RV C_SignUpdate(CK_SESSION_HANDLE session,
                            CK_BYTE *part,
-                           CK_ULONG part_len)
+                           CK_ULONG part_len) nogil
 
         CK_RV C_SignFinal(CK_SESSION_HANDLE session,
                           CK_BYTE *signature,
@@ -444,71 +444,71 @@ cdef extern from '../extern/cryptoki.h':
 
         CK_RV C_SignRecoverInit(CK_SESSION_HANDLE session,
                                 CK_MECHANISM *mechanism,
-                                CK_OBJECT_HANDLE key)
+                                CK_OBJECT_HANDLE key) nogil
 
         CK_RV C_SignRecover(CK_SESSION_HANDLE session,
                             CK_BYTE *text,
                             CK_ULONG text_len,
                             CK_BYTE *signature,
-                            CK_ULONG *sig_len)
+                            CK_ULONG *sig_len) nogil
 
 
         ## Verifying signatures and MACs
         CK_RV C_VerifyInit(CK_SESSION_HANDLE session,
                            CK_MECHANISM *mechanism,
-                           CK_OBJECT_HANDLE key)
+                           CK_OBJECT_HANDLE key) nogil
 
         CK_RV C_Verify(CK_SESSION_HANDLE session,
                        CK_BYTE *text,
                        CK_ULONG text_len,
                        CK_BYTE *signature,
-                       CK_ULONG sig_len)
+                       CK_ULONG sig_len) nogil
 
         CK_RV C_VerifyUpdate(CK_SESSION_HANDLE session,
                              CK_BYTE *text,
-                             CK_ULONG text_len)
+                             CK_ULONG text_len) nogil
 
         CK_RV C_VerifyFinal(CK_SESSION_HANDLE session,
                             CK_BYTE *signature,
-                            CK_ULONG sig_len)
+                            CK_ULONG sig_len) nogil
 
         CK_RV C_VerifyRecoverInit(CK_SESSION_HANDLE session,
                                   CK_MECHANISM *mechanism,
-                                  CK_OBJECT_HANDLE key)
+                                  CK_OBJECT_HANDLE key) nogil
 
         CK_RV C_VerifyRecover(CK_SESSION_HANDLE session,
                               CK_BYTE *text,
                               CK_ULONG text_len,
                               CK_BYTE *signature,
-                              CK_ULONG sig_len)
+                              CK_ULONG sig_len) nogil
 
         ## dual-function crypto operations
         CK_RV C_DigestEncryptUpdate(CK_SESSION_HANDLE session,
                                     CK_BYTE *data,
                                     CK_ULONG data_len,
                                     CK_BYTE *encrypted,
-                                    CK_ULONG *encrypted_len)
+                                    CK_ULONG *encrypted_len) nogil
 
         CK_RV C_DecryptDigestUpdate(CK_SESSION_HANDLE session,
                                     CK_BYTE *encrypted,
                                     CK_ULONG encrypted_len,
                                     CK_BYTE *data,
-                                    CK_ULONG *data_len)
+                                    CK_ULONG *data_len) nogil
 
         CK_RV C_SignEncryptUpdate(CK_SESSION_HANDLE session,
                                   CK_BYTE *part,
-                                  CK_ULONG part_len)
+                                  CK_ULONG part_len) nogil
 
         CK_RV C_DecryptVerifyUpdate(CK_SESSION_HANDLE session,
                                     CK_BYTE *text,
-                                    CK_ULONG text_len)
+                                    CK_ULONG text_len) nogil
 
         ## key management
         CK_RV C_GenerateKey(CK_SESSION_HANDLE session,
                             CK_MECHANISM *mechanism,
                             CK_ATTRIBUTE *template,
                             CK_ULONG count,
-                            CK_OBJECT_HANDLE *key)
+                            CK_OBJECT_HANDLE *key) nogil
 
         CK_RV C_GenerateKeyPair(CK_SESSION_HANDLE session,
                                 CK_MECHANISM *mechanism,
@@ -517,14 +517,14 @@ cdef extern from '../extern/cryptoki.h':
                                 CK_ATTRIBUTE *private_template,
                                 CK_ULONG private_count,
                                 CK_OBJECT_HANDLE *public_key,
-                                CK_OBJECT_HANDLE *private_key)
+                                CK_OBJECT_HANDLE *private_key) nogil
 
         CK_RV C_WrapKey(CK_SESSION_HANDLE session,
                         CK_MECHANISM *mechanism,
                         CK_OBJECT_HANDLE wrapping_key,
                         CK_OBJECT_HANDLE key_to_wrap,
                         CK_BYTE *wrapped_key,
-                        CK_ULONG *wrapped_key_len)
+                        CK_ULONG *wrapped_key_len) nogil
 
         CK_RV C_UnwrapKey(CK_SESSION_HANDLE session,
                           CK_MECHANISM *mechanism,
@@ -533,37 +533,35 @@ cdef extern from '../extern/cryptoki.h':
                           CK_ULONG wrapped_key_len,
                           CK_ATTRIBUTE *attrs,
                           CK_ULONG attr_len,
-                          CK_OBJECT_HANDLE *unwrapped_key)
+                          CK_OBJECT_HANDLE *unwrapped_key) nogil
 
         CK_RV C_DeriveKey(CK_SESSION_HANDLE session,
                           CK_MECHANISM *mechanism,
                           CK_OBJECT_HANDLE src_key,
                           CK_ATTRIBUTE *template,
                           CK_ULONG count,
-                          CK_OBJECT_HANDLE *new_key)
+                          CK_OBJECT_HANDLE *new_key) nogil
 
         ## random number generation
         CK_RV C_SeedRandom(CK_SESSION_HANDLE session,
                            CK_BYTE *seed,
-                           CK_ULONG length)
+                           CK_ULONG length) nogil
 
         CK_RV C_GenerateRandom(CK_SESSION_HANDLE session,
                                CK_BYTE *random,
-                               CK_ULONG length)
+                               CK_ULONG length) nogil
 
 
         ## parallel processing
-        CK_RV C_GetFunctionStatus(CK_SESSION_HANDLE session)
+        CK_RV C_GetFunctionStatus(CK_SESSION_HANDLE session) nogil
 
-        CK_RV C_CancelFunction(CK_SESSION_HANDLE session)
+        CK_RV C_CancelFunction(CK_SESSION_HANDLE session) nogil
 
         ## smart card events
         CK_RV C_WaitForSlotEvent(CK_FLAGS flags,
                                  CK_SLOT_ID *slot,
-                                 void *pRserved)
+                                 void *pRserved) nogil
 
 # The only external API call that must be defined in a PKCS#11 library
 # All other APIs are taken from the CK_FUNCTION_LIST table
-ctypedef CK_RV (*C_GetFunctionList_ptr) (CK_FUNCTION_LIST **)
-
-
+ctypedef CK_RV (*C_GetFunctionList_ptr) (CK_FUNCTION_LIST **) nogil

--- a/pkcs11/_pkcs11_defn.pxd
+++ b/pkcs11/_pkcs11_defn.pxd
@@ -432,7 +432,7 @@ cdef extern from '../extern/cryptoki.h':
                      CK_BYTE *text,
                      CK_ULONG text_len,
                      CK_BYTE *signature,
-                     CK_ULONG *sig_len)
+                     CK_ULONG *sig_len) nogil
 
         CK_RV C_SignUpdate(CK_SESSION_HANDLE session,
                            CK_BYTE *part,
@@ -440,7 +440,7 @@ cdef extern from '../extern/cryptoki.h':
 
         CK_RV C_SignFinal(CK_SESSION_HANDLE session,
                           CK_BYTE *signature,
-                          CK_ULONG *sig_len)
+                          CK_ULONG *sig_len) nogil
 
         CK_RV C_SignRecoverInit(CK_SESSION_HANDLE session,
                                 CK_MECHANISM *mechanism,


### PR DESCRIPTION
Release the Python global interpreter lock while making calls to the
PKCS#11 C_Sign and C_SignFinal functions, to allow other Python threads
to run while a sign operation is in progress. This is helpful when the
sign call blocks waiting for user interaction, such as the user needing
to touch a security key.