### PR TITLE
UnicodeDecodeError(UTF-8) Fixed

### DIFF
--- a/pkcs11/types.py
+++ b/pkcs11/types.py
@@ -32,7 +32,10 @@ PROTECTED_AUTH = object()
 
 def _CK_UTF8CHAR_to_str(data):
     """Convert CK_UTF8CHAR to string."""
-    return data.rstrip(b'\0').decode('utf-8').rstrip()
+    try:
+        return data.rstrip(b'\0').decode('utf-8').rstrip()
+    except UnicodeError:
+        return data.rstrip(b'\0').decode('utf-16').rstrip()
 
 
 def _CK_VERSION_to_tuple(data):


### PR DESCRIPTION
I think it's about Turkish characters in USB Dongle names. Not sure but solved.