### PR TITLE
Add AES Key Derivation Support (ECB,CBC Encrypt)

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -4,6 +4,7 @@ setuptools_scm
 # Used for tests
 oscrypto
 cryptography
+parameterized
 
 sphinx
 sphinx-rtd-theme

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,6 +22,7 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 oscrypto==1.2.0           # via -r dev-requirements.in
 packaging==20.1           # via sphinx
+parameterized==0.7.4      # via -r dev-requirements.in
 pycodestyle==2.5.0        # via flake8
 pycparser==2.19           # via cffi
 pyflakes==2.1.1           # via flake8

--- a/pkcs11/_pkcs11.pyx
+++ b/pkcs11/_pkcs11.pyx
@@ -109,6 +109,8 @@ cdef class MechanismWithParam:
         cdef CK_RSA_PKCS_OAEP_PARAMS *oaep_params
         cdef CK_RSA_PKCS_PSS_PARAMS *pss_params
         cdef CK_ECDH1_DERIVE_PARAMS *ecdh1_params
+        cdef CK_KEY_DERIVATION_STRING_DATA *aes_ecb_params
+        cdef CK_AES_CBC_ENCRYPT_DATA_PARAMS *aes_cbc_params
 
         # Unpack mechanism parameters
         if mechanism is Mechanism.RSA_PKCS_OAEP:
@@ -162,6 +164,22 @@ cdef class MechanismWithParam:
 
             ecdh1_params.pPublicData = public_data
             ecdh1_params.ulPublicDataLen = <CK_ULONG> len(public_data)
+
+        elif mechanism is Mechanism.AES_ECB_ENCRYPT_DATA:
+            paramlen = sizeof(CK_KEY_DERIVATION_STRING_DATA)
+            self.param = aes_ecb_params = \
+                <CK_KEY_DERIVATION_STRING_DATA *> PyMem_Malloc(paramlen)
+            aes_ecb_params.pData = <CK_BYTE *> param
+            aes_ecb_params.ulLen = len(param)
+
+        elif mechanism is Mechanism.AES_CBC_ENCRYPT_DATA:
+            paramlen = sizeof(CK_AES_CBC_ENCRYPT_DATA_PARAMS)
+            self.param = aes_cbc_params = \
+                    <CK_AES_CBC_ENCRYPT_DATA_PARAMS *> PyMem_Malloc(paramlen)
+            (iv, data) = param
+            aes_cbc_params.iv = [<CK_BYTE> x for x in iv[:16]]
+            aes_cbc_params.pData = <CK_BYTE *> data
+            aes_cbc_params.length = len(data)
 
         elif isinstance(param, bytes):
             self.data.pParameter = <CK_BYTE *> param

--- a/pkcs11/_pkcs11.pyx
+++ b/pkcs11/_pkcs11.pyx
@@ -177,7 +177,7 @@ cdef class MechanismWithParam:
             self.param = aes_cbc_params = \
                     <CK_AES_CBC_ENCRYPT_DATA_PARAMS *> PyMem_Malloc(paramlen)
             (iv, data) = param
-            aes_cbc_params.iv = [<CK_BYTE> x for x in iv[:16]]
+            aes_cbc_params.iv = iv[:16]
             aes_cbc_params.pData = <CK_BYTE *> data
             aes_cbc_params.length = len(data)
 

--- a/pkcs11/_pkcs11_defn.pxd
+++ b/pkcs11/_pkcs11_defn.pxd
@@ -242,6 +242,15 @@ cdef extern from '../extern/cryptoki.h':
         CK_ULONG ulPublicDataLen
         CK_BYTE *pPublicData
 
+    ctypedef struct CK_KEY_DERIVATION_STRING_DATA:
+        CK_BYTE *pData
+        CK_ULONG ulLen
+
+    ctypedef struct CK_AES_CBC_ENCRYPT_DATA_PARAMS:
+        CK_BYTE iv[16]
+        CK_BYTE *pData
+        CK_ULONG length
+
     cdef struct CK_FUNCTION_LIST:
         CK_VERSION version
         ## pointers to library functions are stored here

--- a/tests/test_aes.py
+++ b/tests/test_aes.py
@@ -126,16 +126,16 @@ class AESTests(TestCase):
                          key2[pkcs11.Attribute.VALUE])
 
     @parameterized.expand([
-        ("POSITIVE_128_BIT",            128, 16),
-        ("POSITIVE_128_BIT_LONG_IV",    128, 32),
-        ("NEGATIVE_128_BIT_BAD_IV",     128, 15),
-        ("POSITIVE_256_BIT_LONG_IV",    256, 32),
-        ("NEGATIVE_256_BIT_SHORT_IV",   256, 16),
-        ("NEGATIVE_256_BIT_BAD_IV",     256, 31),
+        ("POSITIVE_128_BIT",            128, 16, TestCase.assertIsNotNone),
+        ("POSITIVE_128_BIT_LONG_IV",    128, 32, TestCase.assertIsNotNone),
+        ("NEGATIVE_128_BIT_BAD_IV",     128, 15, TestCase.assertIsNone),
+        ("POSITIVE_256_BIT_LONG_IV",    256, 32, TestCase.assertIsNotNone),
+        ("NEGATIVE_256_BIT_SHORT_IV",   256, 16, TestCase.assertIsNone),
+        ("NEGATIVE_256_BIT_BAD_IV",     256, 31, TestCase.assertIsNone),
     ])
     @requires(Mechanism.AES_ECB_ENCRYPT_DATA)
     @FIXME.opencryptoki  # can't set key attributes
-    def test_derive_using_ecb_encrypt(self, test_type, test_key_length, iv_length):
+    def test_derive_using_ecb_encrypt(self, test_type, test_key_length, iv_length, assert_fn):
         """Function to test AES Key Derivation using the ECB_ENCRYPT Mechanism.
 
         Refer to Section 2.15 of http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/errata01/os/pkcs11-curr-v2.40-errata01-os-complete.html#_Toc441850521
@@ -169,10 +169,7 @@ class AESTests(TestCase):
                 pkcs11.exceptions.FunctionFailed) as e:
             derived_key = None
 
-        if test_type.startswith("NEGATIVE"):
-            self.assertTrue(derived_key is None, "Unexpected {}-bit Derived Key".format(test_key_length))
-        else:
-            self.assertTrue(derived_key is not None, "Failed to derive {}-bit Derived Key".format(test_key_length))
+        assert_fn(self, derived_key, "{}-bit Key Derivation Failure".format(test_key_length))
 
     @parameterized.expand([
         ("POSITIVE_128_BIT",            128, 16),
@@ -229,19 +226,19 @@ class AESTests(TestCase):
         self.assertEqual(text, data)
 
     @parameterized.expand([
-        ("POSITIVE_128_BIT",            128, 16, 16),
-        ("POSITIVE_128_BIT_LONG_DATA",  128, 16, 64),
-        ("NEGATIVE_128_BIT_BAD_IV",     128, 15, 16),
-        ("NEGATIVE_128_BIT_BAD_DATA",   128, 16, 31),
-        ("POSITIVE_256_BIT",            256, 16, 32),
-        ("POSITIVE_256_BIT_LONG_DATA",  256, 16, 64),
-        ("NEGATIVE_256_BIT_BAD_IV",     256, 15, 16),
-        ("NEGATIVE_256_BIT_BAD_DATA",   256, 16, 31),
-        ("NEGATIVE_256_BIT_SHORT_DATA", 256, 16, 16),
+        ("POSITIVE_128_BIT",            128, 16, 16, TestCase.assertIsNotNone),
+        ("POSITIVE_128_BIT_LONG_DATA",  128, 16, 64, TestCase.assertIsNotNone),
+        ("NEGATIVE_128_BIT_BAD_IV",     128, 15, 16, TestCase.assertIsNone),
+        ("NEGATIVE_128_BIT_BAD_DATA",   128, 16, 31, TestCase.assertIsNone),
+        ("POSITIVE_256_BIT",            256, 16, 32, TestCase.assertIsNotNone),
+        ("POSITIVE_256_BIT_LONG_DATA",  256, 16, 64, TestCase.assertIsNotNone),
+        ("NEGATIVE_256_BIT_BAD_IV",     256, 15, 16, TestCase.assertIsNone),
+        ("NEGATIVE_256_BIT_BAD_DATA",   256, 16, 31, TestCase.assertIsNone),
+        ("NEGATIVE_256_BIT_SHORT_DATA", 256, 16, 16, TestCase.assertIsNone),
     ])
     @requires(Mechanism.AES_CBC_ENCRYPT_DATA)
     @FIXME.opencryptoki  # can't set key attributes
-    def test_derive_using_cbc_encrypt(self, test_type, test_key_length, iv_length, data_length):
+    def test_derive_using_cbc_encrypt(self, test_type, test_key_length, iv_length, data_length, assert_fn):
         """Function to test AES Key Derivation using the CBC_ENCRYPT Mechanism.
 
         Refer to Section 2.15 of http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/errata01/os/pkcs11-curr-v2.40-errata01-os-complete.html#_Toc441850521
@@ -277,10 +274,7 @@ class AESTests(TestCase):
                 IndexError) as e:
             derived_key = None
 
-        if test_type.startswith("NEGATIVE"):
-            self.assertTrue(derived_key is None, "Unexpected {}-bit Derived Key".format(test_key_length))
-        else:
-            self.assertTrue(derived_key is not None, "Failed to derive {}-bit Derived Key".format(test_key_length))
+        assert_fn(self, derived_key, "{}-bit Key Derivation Failure".format(test_key_length))
 
     @parameterized.expand([
         ("POSITIVE_128_BIT",            128, 16, 16),

--- a/tests/test_aes.py
+++ b/tests/test_aes.py
@@ -7,6 +7,7 @@ from pkcs11 import Mechanism
 
 from . import TestCase, requires, FIXME
 
+from parameterized import parameterized
 
 class AESTests(TestCase):
 
@@ -123,3 +124,127 @@ class AESTests(TestCase):
 
         self.assertEqual(key[pkcs11.Attribute.VALUE],
                          key2[pkcs11.Attribute.VALUE])
+
+    @parameterized.expand([
+        ("POSITIVE_128_BIT",            128, 16),
+        ("POSITIVE_128_BIT_LONG_IV",    128, 32),
+        ("NEGATIVE_128_BIT_BAD_IV",     128, 15),
+        ("POSITIVE_256_BIT_LONG_IV",    256, 32),
+        ("NEGATIVE_256_BIT_SHORT_IV",   256, 16),
+        ("NEGATIVE_256_BIT_BAD_IV",     256, 31),
+    ])
+    @requires(Mechanism.AES_ECB_ENCRYPT_DATA)
+    @FIXME.opencryptoki  # can't set key attributes
+    def test_derive_ecb_encrypt(self, test_type, test_key_length, iv_length):
+        """
+        Function to test AES Key Derivation using the ECB_ENCRYPT Mechanism.
+
+        Refer to Section 2.15 of http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/errata01/os/pkcs11-curr-v2.40-errata01-os-complete.html#_Toc441850521
+        """
+
+        # Create the Master Key
+        capabilities = pkcs11.defaults.DEFAULT_KEY_CAPABILITIES[pkcs11.KeyType.AES]
+        capabilities |= pkcs11.MechanismFlag.DERIVE
+        key = self.session.generate_key(pkcs11.KeyType.AES, key_length=test_key_length,
+                                        capabilities=capabilities,
+                                        template={
+                                            pkcs11.Attribute.EXTRACTABLE: True,
+                                            pkcs11.Attribute.DERIVE: True,
+                                            pkcs11.Attribute.SENSITIVE: False,
+                                        })
+
+        self.assertTrue(key is not None, f"Failed to create {test_key_length}-bit Master Key")
+
+        # Derive a Key from the Master Key
+        iv = b'0' * iv_length
+        try:
+            derived_key = key.derive_key(pkcs11.KeyType.AES, key_length=test_key_length,
+                                         capabilities=capabilities,
+                                         mechanism=Mechanism.AES_ECB_ENCRYPT_DATA,
+                                         mechanism_param=iv,
+                                         template={
+                                             pkcs11.Attribute.EXTRACTABLE: True,
+                                             pkcs11.Attribute.SENSITIVE: False,
+                                         })
+        except (pkcs11.exceptions.MechanismParamInvalid,
+                pkcs11.exceptions.FunctionFailed) as e:
+            derived_key = None
+
+        if test_type.startswith("NEGATIVE"):
+            self.assertTrue(derived_key is None, f"Unexpected {test_key_length}-bit Derived Key")
+        else:
+            self.assertTrue(derived_key is not None, f"Failed to derive {test_key_length}-bit Derived Key")
+
+            # Test capability of Key to Encrypt/Decrypt data
+            data = b'HELLO WORLD' * 1024
+
+            iv = self.session.generate_random(128)
+            crypttext = self.key.encrypt(data, mechanism_param=iv)
+            text = self.key.decrypt(crypttext, mechanism_param=iv)
+
+            self.assertEqual(text, data)
+
+    @parameterized.expand([
+        ("POSITIVE_128_BIT",            128, 16, 16),
+        ("POSITIVE_128_BIT_LONG_DATA",  128, 16, 64),
+        ("NEGATIVE_128_BIT_BAD_IV",     128, 15, 16),
+        ("NEGATIVE_128_BIT_BAD_DATA",   128, 16, 31),
+        ("POSITIVE_256_BIT",            256, 16, 32),
+        ("POSITIVE_256_BIT_LONG_DATA",  256, 16, 64),
+        ("NEGATIVE_256_BIT_BAD_IV",     256, 15, 16),
+        ("NEGATIVE_256_BIT_BAD_DATA",   256, 16, 31),
+        ("NEGATIVE_256_BIT_SHORT_DATA", 256, 16, 16),
+    ])
+    @requires(Mechanism.AES_CBC_ENCRYPT_DATA)
+    @FIXME.opencryptoki  # can't set key attributes
+    def test_derive_cbc_encrypt(self, test_type, test_key_length, iv_length, data_length):
+        """
+        Function to test AES Key Derivation using the CBC_ENCRYPT Mechanism.
+
+        Refer to Section 2.15 of http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/errata01/os/pkcs11-curr-v2.40-errata01-os-complete.html#_Toc441850521
+        """
+
+        # Create the Master Key
+        capabilities = pkcs11.defaults.DEFAULT_KEY_CAPABILITIES[pkcs11.KeyType.AES]
+        capabilities |= pkcs11.MechanismFlag.DERIVE
+        key = self.session.generate_key(pkcs11.KeyType.AES, key_length=test_key_length,
+                                        capabilities=capabilities,
+                                        template={
+                                            pkcs11.Attribute.EXTRACTABLE: True,
+                                            pkcs11.Attribute.DERIVE: True,
+                                            pkcs11.Attribute.SENSITIVE: False,
+                                        })
+
+        self.assertTrue(key is not None, f"Failed to create {test_key_length}-bit Master Key")
+
+        # Derive a Key from the Master Key
+        iv = b'0' * iv_length
+        data = b'1' * data_length
+        try:
+            derived_key = key.derive_key(pkcs11.KeyType.AES, key_length=test_key_length,
+                                         capabilities=capabilities,
+                                         mechanism=Mechanism.AES_CBC_ENCRYPT_DATA,
+                                         mechanism_param=(iv, data),
+                                         template={
+                                             pkcs11.Attribute.EXTRACTABLE: True,
+                                             pkcs11.Attribute.SENSITIVE: False,
+                                         })
+        except (pkcs11.exceptions.MechanismParamInvalid,
+                pkcs11.exceptions.FunctionFailed,
+                IndexError) as e:
+            derived_key = None
+
+        if test_type.startswith("NEGATIVE"):
+            self.assertTrue(derived_key is None, f"Unexpected {test_key_length}-bit Derived Key")
+        else:
+            self.assertTrue(derived_key is not None, f"Failed to derive {test_key_length}-bit Derived Key")
+
+            # Test capability of Key to Encrypt/Decrypt data
+            data = b'HELLO WORLD' * 1024
+
+            iv = self.session.generate_random(128)
+            crypttext = self.key.encrypt(data, mechanism_param=iv)
+            text = self.key.decrypt(crypttext, mechanism_param=iv)
+
+            self.assertEqual(text, data)
+

--- a/tests/test_aes.py
+++ b/tests/test_aes.py
@@ -135,9 +135,8 @@ class AESTests(TestCase):
     ])
     @requires(Mechanism.AES_ECB_ENCRYPT_DATA)
     @FIXME.opencryptoki  # can't set key attributes
-    def test_derive_ecb_encrypt(self, test_type, test_key_length, iv_length):
-        """
-        Function to test AES Key Derivation using the ECB_ENCRYPT Mechanism.
+    def test_derive_using_ecb_encrypt(self, test_type, test_key_length, iv_length):
+        """Function to test AES Key Derivation using the ECB_ENCRYPT Mechanism.
 
         Refer to Section 2.15 of http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/errata01/os/pkcs11-curr-v2.40-errata01-os-complete.html#_Toc441850521
         """
@@ -175,14 +174,59 @@ class AESTests(TestCase):
         else:
             self.assertTrue(derived_key is not None, f"Failed to derive {test_key_length}-bit Derived Key")
 
-            # Test capability of Key to Encrypt/Decrypt data
-            data = b'HELLO WORLD' * 1024
+    @parameterized.expand([
+        ("POSITIVE_128_BIT",            128, 16),
+        ("POSITIVE_256_BIT_LONG_IV",    256, 32),
+    ])
+    @requires(Mechanism.AES_ECB_ENCRYPT_DATA)
+    @FIXME.opencryptoki  # can't set key attributes
+    def test_encrypt_with_key_derived_using_ecb_encrypt(self, test_type, test_key_length, iv_length):
+        """Function to test Data Encryption/Decryption using a Derived AES Key.
 
-            iv = self.session.generate_random(128)
-            crypttext = self.key.encrypt(data, mechanism_param=iv)
-            text = self.key.decrypt(crypttext, mechanism_param=iv)
+        Function to test Data Encryption/Decryption using an AES Key
+        Derived by the ECB_ENCRYPT Mechanism.
 
-            self.assertEqual(text, data)
+        Refer to Section 2.15 of http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/errata01/os/pkcs11-curr-v2.40-errata01-os-complete.html#_Toc441850521
+        """
+
+        # Create the Master Key
+        capabilities = pkcs11.defaults.DEFAULT_KEY_CAPABILITIES[pkcs11.KeyType.AES]
+        capabilities |= pkcs11.MechanismFlag.DERIVE
+        key = self.session.generate_key(pkcs11.KeyType.AES, key_length=test_key_length,
+                                        capabilities=capabilities,
+                                        template={
+                                            pkcs11.Attribute.EXTRACTABLE: True,
+                                            pkcs11.Attribute.DERIVE: True,
+                                            pkcs11.Attribute.SENSITIVE: False,
+                                        })
+
+        self.assertTrue(key is not None, f"Failed to create {test_key_length}-bit Master Key")
+
+        # Derive a Key from the Master Key
+        iv = b'0' * iv_length
+        try:
+            derived_key = key.derive_key(pkcs11.KeyType.AES, key_length=test_key_length,
+                                         capabilities=capabilities,
+                                         mechanism=Mechanism.AES_ECB_ENCRYPT_DATA,
+                                         mechanism_param=iv,
+                                         template={
+                                             pkcs11.Attribute.EXTRACTABLE: True,
+                                             pkcs11.Attribute.SENSITIVE: False,
+                                         })
+        except (pkcs11.exceptions.MechanismParamInvalid,
+                pkcs11.exceptions.FunctionFailed) as e:
+            derived_key = None
+
+        self.assertTrue(derived_key is not None, f"Failed to derive {test_key_length}-bit Derived Key")
+
+        # Test capability of Key to Encrypt/Decrypt data
+        data = b'HELLO WORLD' * 1024
+
+        iv = self.session.generate_random(128)
+        crypttext = self.key.encrypt(data, mechanism_param=iv)
+        text = self.key.decrypt(crypttext, mechanism_param=iv)
+
+        self.assertEqual(text, data)
 
     @parameterized.expand([
         ("POSITIVE_128_BIT",            128, 16, 16),
@@ -197,9 +241,8 @@ class AESTests(TestCase):
     ])
     @requires(Mechanism.AES_CBC_ENCRYPT_DATA)
     @FIXME.opencryptoki  # can't set key attributes
-    def test_derive_cbc_encrypt(self, test_type, test_key_length, iv_length, data_length):
-        """
-        Function to test AES Key Derivation using the CBC_ENCRYPT Mechanism.
+    def test_derive_using_cbc_encrypt(self, test_type, test_key_length, iv_length, data_length):
+        """Function to test AES Key Derivation using the CBC_ENCRYPT Mechanism.
 
         Refer to Section 2.15 of http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/errata01/os/pkcs11-curr-v2.40-errata01-os-complete.html#_Toc441850521
         """
@@ -239,12 +282,59 @@ class AESTests(TestCase):
         else:
             self.assertTrue(derived_key is not None, f"Failed to derive {test_key_length}-bit Derived Key")
 
-            # Test capability of Key to Encrypt/Decrypt data
-            data = b'HELLO WORLD' * 1024
+    @parameterized.expand([
+        ("POSITIVE_128_BIT",            128, 16, 16),
+        ("POSITIVE_256_BIT",            256, 16, 32),
+        ("POSITIVE_256_BIT_LONG_DATA",  256, 16, 64),
+    ])
+    @requires(Mechanism.AES_CBC_ENCRYPT_DATA)
+    @FIXME.opencryptoki  # can't set key attributes
+    def test_encrypt_with_key_derived_using_cbc_encrypt(self, test_type, test_key_length, iv_length, data_length):
+        """Function to test Data Encryption/Decryption using a Derived AES Key.
 
-            iv = self.session.generate_random(128)
-            crypttext = self.key.encrypt(data, mechanism_param=iv)
-            text = self.key.decrypt(crypttext, mechanism_param=iv)
+        Function to test Data Encryption/Decryption using an AES Key
+        Derived by the CBC_ENCRYPT Mechanism.
 
-            self.assertEqual(text, data)
+        Refer to Section 2.15 of http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/errata01/os/pkcs11-curr-v2.40-errata01-os-complete.html#_Toc441850521
+        """
 
+        # Create the Master Key
+        capabilities = pkcs11.defaults.DEFAULT_KEY_CAPABILITIES[pkcs11.KeyType.AES]
+        capabilities |= pkcs11.MechanismFlag.DERIVE
+        key = self.session.generate_key(pkcs11.KeyType.AES, key_length=test_key_length,
+                                        capabilities=capabilities,
+                                        template={
+                                            pkcs11.Attribute.EXTRACTABLE: True,
+                                            pkcs11.Attribute.DERIVE: True,
+                                            pkcs11.Attribute.SENSITIVE: False,
+                                        })
+
+        self.assertTrue(key is not None, f"Failed to create {test_key_length}-bit Master Key")
+
+        # Derive a Key from the Master Key
+        iv = b'0' * iv_length
+        data = b'1' * data_length
+        try:
+            derived_key = key.derive_key(pkcs11.KeyType.AES, key_length=test_key_length,
+                                         capabilities=capabilities,
+                                         mechanism=Mechanism.AES_CBC_ENCRYPT_DATA,
+                                         mechanism_param=(iv, data),
+                                         template={
+                                             pkcs11.Attribute.EXTRACTABLE: True,
+                                             pkcs11.Attribute.SENSITIVE: False,
+                                         })
+        except (pkcs11.exceptions.MechanismParamInvalid,
+                pkcs11.exceptions.FunctionFailed,
+                IndexError) as e:
+            derived_key = None
+
+        self.assertTrue(derived_key is not None, f"Failed to derive {test_key_length}-bit Derived Key")
+
+        # Test capability of Key to Encrypt/Decrypt data
+        data = b'HELLO WORLD' * 1024
+
+        iv = self.session.generate_random(128)
+        crypttext = self.key.encrypt(data, mechanism_param=iv)
+        text = self.key.decrypt(crypttext, mechanism_param=iv)
+
+        self.assertEqual(text, data)

--- a/tests/test_aes.py
+++ b/tests/test_aes.py
@@ -152,7 +152,7 @@ class AESTests(TestCase):
                                             pkcs11.Attribute.SENSITIVE: False,
                                         })
 
-        self.assertTrue(key is not None, f"Failed to create {test_key_length}-bit Master Key")
+        self.assertTrue(key is not None, "Failed to create {}-bit Master Key".format(test_key_length))
 
         # Derive a Key from the Master Key
         iv = b'0' * iv_length
@@ -170,9 +170,9 @@ class AESTests(TestCase):
             derived_key = None
 
         if test_type.startswith("NEGATIVE"):
-            self.assertTrue(derived_key is None, f"Unexpected {test_key_length}-bit Derived Key")
+            self.assertTrue(derived_key is None, "Unexpected {}-bit Derived Key".format(test_key_length))
         else:
-            self.assertTrue(derived_key is not None, f"Failed to derive {test_key_length}-bit Derived Key")
+            self.assertTrue(derived_key is not None, "Failed to derive {}-bit Derived Key".format(test_key_length))
 
     @parameterized.expand([
         ("POSITIVE_128_BIT",            128, 16),
@@ -200,7 +200,7 @@ class AESTests(TestCase):
                                             pkcs11.Attribute.SENSITIVE: False,
                                         })
 
-        self.assertTrue(key is not None, f"Failed to create {test_key_length}-bit Master Key")
+        self.assertTrue(key is not None, "Failed to create {}-bit Master Key".format(test_key_length))
 
         # Derive a Key from the Master Key
         iv = b'0' * iv_length
@@ -217,7 +217,7 @@ class AESTests(TestCase):
                 pkcs11.exceptions.FunctionFailed) as e:
             derived_key = None
 
-        self.assertTrue(derived_key is not None, f"Failed to derive {test_key_length}-bit Derived Key")
+        self.assertTrue(derived_key is not None, "Failed to derive {}-bit Derived Key".format(test_key_length))
 
         # Test capability of Key to Encrypt/Decrypt data
         data = b'HELLO WORLD' * 1024
@@ -258,7 +258,7 @@ class AESTests(TestCase):
                                             pkcs11.Attribute.SENSITIVE: False,
                                         })
 
-        self.assertTrue(key is not None, f"Failed to create {test_key_length}-bit Master Key")
+        self.assertTrue(key is not None, "Failed to create {}-bit Master Key".format(test_key_length))
 
         # Derive a Key from the Master Key
         iv = b'0' * iv_length
@@ -278,9 +278,9 @@ class AESTests(TestCase):
             derived_key = None
 
         if test_type.startswith("NEGATIVE"):
-            self.assertTrue(derived_key is None, f"Unexpected {test_key_length}-bit Derived Key")
+            self.assertTrue(derived_key is None, "Unexpected {}-bit Derived Key".format(test_key_length))
         else:
-            self.assertTrue(derived_key is not None, f"Failed to derive {test_key_length}-bit Derived Key")
+            self.assertTrue(derived_key is not None, "Failed to derive {}-bit Derived Key".format(test_key_length))
 
     @parameterized.expand([
         ("POSITIVE_128_BIT",            128, 16, 16),
@@ -309,7 +309,7 @@ class AESTests(TestCase):
                                             pkcs11.Attribute.SENSITIVE: False,
                                         })
 
-        self.assertTrue(key is not None, f"Failed to create {test_key_length}-bit Master Key")
+        self.assertTrue(key is not None, "Failed to create {}-bit Master Key".format(test_key_length))
 
         # Derive a Key from the Master Key
         iv = b'0' * iv_length
@@ -328,7 +328,7 @@ class AESTests(TestCase):
                 IndexError) as e:
             derived_key = None
 
-        self.assertTrue(derived_key is not None, f"Failed to derive {test_key_length}-bit Derived Key")
+        self.assertTrue(derived_key is not None, "Failed to derive {}-bit Derived Key".format(test_key_length))
 
         # Test capability of Key to Encrypt/Decrypt data
         data = b'HELLO WORLD' * 1024


### PR DESCRIPTION
Additional Information:

1. Added AES Key Derivation mechanisms described in
   PKCS11 v2.4.0 Section 2.15:
  - CKM_AES_ECB_ENCRYPT_DATA
  - CKM_AES_CBC_ENCRYPT_DATA

Sanity Testing:

1. Build Validation:
python setup.py build_ext --inplace

2. AES Testing:
export PKCS11_MODULE=XXX
export PKCS11_TOKEN_LABEL=XXX
export PKCS11_TOKEN_PIN=XXX
export PKCS11_TOKEN_SO_PIN=XXX
pytest ./tests/test_aes.py

Signed-off-by: Akshitij Malik