### PR TITLE
Allow vendor defined CK_USER_TYPE in C_Login

### DIFF
--- a/pkcs11/types.py
+++ b/pkcs11/types.py
@@ -202,7 +202,7 @@ class Token:
     def __eq__(self, other):
         return self.slot == other.slot
 
-    def open(self, rw=False, user_pin=None, so_pin=None):
+    def open(self, rw=False, user_pin=None, so_pin=None, user_type=None):
         """
         Open a session on the token and optionally log in as a user or
         security officer (pass one of `user_pin` or `so_pin`). Pass PROTECTED_AUTH to
@@ -220,6 +220,9 @@ class Token:
         :param bytes user_pin: Authenticate to this session as a user.
         :param bytes so_pin: Authenticate to this session as a
             security officer.
+        :param user_type: Sets the userType parameter to C_Login.
+            Allows for vendor-defined values. Defaults to UserType.SO if
+            so_pin is set, otherwise UserType.USER.
 
         :rtype: Session
         """


### PR DESCRIPTION
Thales in Luna HSM 7 SDKs  is using vendor-defined CK_USER_TYPEs. Specifically, Thales is using 0x80000001, 0x80000002, 0x80000003 to allow for some role separation in use of keys in the HSM.

This commit allows specifying the user type as an alternative to the default 0x1(CKU_USER).


```
// extracted from Thales Luna HSM 7 C header files
#define CKU_LIMITED_USER            0x80000001
#define CKU_AUDIT                   0x80000002
#define CKU_LIMITED_CRYPTO_OFFICER  0x80000003
```