### PR TITLE
Fix libraries for Python 3.7 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ import platform
 
 # if compiling using MSVC, we need to link against user32 library
 if platform.system() == 'Windows':
-    libraries = ('user32',)
+    libraries = ['user32']
 else:
-    libraries = ()
+    libraries = []
 
 if __name__ == '__main__':
     with \


### PR DESCRIPTION
Use list instead of tuple.

Fixes: #133 

Reference: https://github.com/danni/python-pkcs11/issues/133#issuecomment-1019577286