### PR TITLE
Fix #133 and support Python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ import platform
 
 # if compiling using MSVC, we need to link against user32 library
 if platform.system() == 'Windows':
-    libraries = ('user32',)
+    libraries = ['user32',]
 else:
-    libraries = ()
+    libraries = []
 
 if __name__ == '__main__':
     with \


### PR DESCRIPTION
Fixes #133 and provides support for automatic installation using "pip install python-pkcs11" in Python 3.10. 

Tested on Windows 11, multiple conda virtual env.