### PR TITLE
Add mechanisms used by Thales Luna HSMs

### DIFF
--- a/pkcs11/mechanisms.py
+++ b/pkcs11/mechanisms.py
@@ -659,6 +659,7 @@ class Mechanism(IntEnum):
     AES_CFB1 = 0x00002108
     AES_KEY_WRAP = 0x00002109
     AES_KEY_WRAP_PAD = 0x0000210A
+    AES_KEY_WRAP_KWP = 0x0000210B
 
     DES_ECB_ENCRYPT_DATA = 0x00001100
     DES_CBC_ENCRYPT_DATA = 0x00001101
@@ -707,6 +708,13 @@ class Mechanism(IntEnum):
     EC_EDWARDS_KEY_PAIR_GEN = 0x00001055
 
     _VENDOR_DEFINED = 0x80000000
+
+    # used by Thales LUNA AES_KWP in cmu importkey
+    # for importing PKCS#8 to the HSM:
+    # _VENDOR_DEFINED + 0x170 = CKM_AES_KW
+    # _VENDOR_DEFINED + 0x171 = CKM_AES_KWP
+    VENDOR_DEFINED_170 = _VENDOR_DEFINED + 0x170
+    VENDOR_DEFINED_171 = _VENDOR_DEFINED + 0x171
 
     def __repr__(self):
         return '<Mechanism.%s>' % self.name


### PR DESCRIPTION
These mechanisms are included in Thales Luna HSMs.

The tool `cmu`  uses `CKM_AES_KWP` to import PKCS#8 keys into the HSM.

With this patch, I am able to replicate the behaviour of `cmu importkey ...` with python-pkcs11.

```
# Thales libCryptoki SDK header files
#define CKM_AES_KEY_WRAP_KWP           0x0000210BUL

#define CKM_AES_KW                              (CKM_VENDOR_DEFINED + 0x170)
#define CKM_AES_KWP                             (CKM_VENDOR_DEFINED + 0x171)
```