### PR TITLE
Fix typo in _pkcs11.pyx

### DIFF
--- a/pkcs11/_pkcs11.pyx
+++ b/pkcs11/_pkcs11.pyx
@@ -377,7 +377,7 @@ class Session(types.Session):
     """Extend Session with implementation."""
 
     def close(self):
-        cdef CK_OBJECT_HANDLE handle = self._handle
+        cdef CK_SESSION_HANDLE handle = self._handle
 
         if self.user_type != UserType.NOBODY:
             with nogil:


### PR DESCRIPTION
Changed typo on L380 from `CK_OBJECT_HANDLE` to `CK_SESSION_HANDLE`.
Resolves #147 