### PR TITLE
_pkcs11.pyx: Fix Python int too large to convert to C ssize_t

### DIFF
--- a/pkcs11/_pkcs11.pyx
+++ b/pkcs11/_pkcs11.pyx
@@ -731,6 +731,7 @@ class Object(types.Object):
         cdef CK_SESSION_HANDLE handle = self.session._handle
         cdef CK_OBJECT_HANDLE obj = self._handle
         cdef CK_ATTRIBUTE template
+        cdef CK_ULONG CK_UNAVAILABLE_INFORMATION = (<CK_ULONG> (~0))
 
         template.type = key
         template.pValue = NULL
@@ -740,6 +741,8 @@ class Object(types.Object):
         with nogil:
             assertRV(_funclist.C_GetAttributeValue(handle, obj, &template, 1))
 
+        if template.ulValueLen >= CK_UNAVAILABLE_INFORMATION:
+            return _unpack_attributes(key, b'0')
         if template.ulValueLen == 0:
             return _unpack_attributes(key, b'')
 


### PR DESCRIPTION
When a key is retrieved it can return CK_UNAVAILABLE_INFORMATION for some of its properties. The CK_UNAVAILABLE_INFORMATION value is set to ~0UL or the largest int possible on a system. The python-pkcs11 library would then try to create a buffer of that size and crash.

This commit adds error checking to make sure when
CK_UNAVAILABLE_INFORMATION is returned that the property value is set to blank and returned immediately.