### PR TITLE
Fix crash when closing sessions with vendor-specific user types

### DIFF
--- a/pkcs11/_pkcs11.pyx
+++ b/pkcs11/_pkcs11.pyx
@@ -892,14 +892,18 @@ cdef class Session(HasFuncList, types.Session):
 
     @property
     def user_type(self):
-        """User type for this session (:class:`pkcs11.constants.UserType`)."""
-        return UserType(self._user_type)
+        """User type for this session (:class:`pkcs11.constants.UserType` or :class:`int` for vendor-specific values)."""
+        try:
+            return UserType(self._user_type)
+        except ValueError:
+            # Return raw value for vendor-specific user types
+            return self._user_type
 
     def close(self):
         cdef CK_SESSION_HANDLE handle = self.handle
         cdef CK_RV retval
 
-        if self.user_type != UserType.NOBODY:
+        if self._user_type != CKU_USER_NOBODY:
             with nogil:
                 retval = self.funclist.C_Logout(handle)
             assertRV(retval)


### PR DESCRIPTION
Fix https://github.com/pyauth/python-pkcs11/issues/230

In the current version of this package, when using a custom user such as the Crypto User -- represented by value `0x80000001` -- on Thales Luna HSM 7, we run into problems when closing a session because:

- The `Session.close()` method calls `Session.user_type()`. (Both methods are defined in `pkcs11/_pkcs11.pyx`.)
- `Session.user_type()` then calls `UserType()`.
- `UserType()`, defined in `pkcs11/constants.py`, crashes because the custom user value `0x80000001` does not match `NOBODY` (999), `SO` (0), or `USER` (1).

This PR fixes the problem by avoiding the indirect call to `UserType()` in `Session.close()`. It also updates `Session.user_type()` to not crash if the user type is a custom user.