### PR TITLE
Declare destroyable attr

### DIFF
--- a/pkcs11/attributes.py
+++ b/pkcs11/attributes.py
@@ -68,6 +68,7 @@ ATTRIBUTE_TYPES: dict[Attribute, Handler] = {
     Attribute.LOCAL: handle_bool,
     Attribute.MODIFIABLE: handle_bool,
     Attribute.COPYABLE: handle_bool,
+    Attribute.DESTROYABLE: handle_bool,
     Attribute.MODULUS: handle_biginteger,
     Attribute.MODULUS_BITS: handle_ulong,
     Attribute.NEVER_EXTRACTABLE: handle_bool,

--- a/pkcs11/constants.py
+++ b/pkcs11/constants.py
@@ -265,6 +265,8 @@ class Attribute(IntEnum):
     """Object can be modified (:class:`bool`)."""
     COPYABLE = 0x00000171
     """Object can be copied (:class:`bool`)."""
+    DESTROYABLE = 0x00000172
+    """Object can be destroyed (:class:`bool`)."""
 
     EC_PARAMS = 0x00000180
     """


### PR DESCRIPTION
This is useful when handling persistent objects, like 802.1AR IDevID.